### PR TITLE
Python3 support

### DIFF
--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -105,7 +105,7 @@ class PrettyPrinter(object):
         """
         Print out a list of values
         """
-        vals = map(str, val)
+        vals = list(map(str, val))
 
         if self.is_paired_list(key):
             # join the values together so each line has a pair

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -4,7 +4,6 @@ if is_python3:
     unicode = str
     
 from mappyfile.tokens import COMPOSITE_NAMES, ATTRIBUTE_NAMES, SINGLETON_COMPOSITE_NAMES
-from itertools import izip
 
 ALL_KEYWORDS = COMPOSITE_NAMES.union(ATTRIBUTE_NAMES).union(SINGLETON_COMPOSITE_NAMES)
 

--- a/tests/maps_downloader.py
+++ b/tests/maps_downloader.py
@@ -11,7 +11,7 @@ for generating an AUTH_KEY
 
 
 activate_this = r'C:\VirtualEnvs\pmsmapserverdev\Scripts\activate_this.py'
-execfile(activate_this, dict(__file__=activate_this))
+exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this))
 
 from github import Github
 import os
@@ -30,9 +30,9 @@ def get_repo():
 def get_all_files(fld, repo):
 
     all_files = []
-    print fld
+    print(fld)
     contents = repo.get_contents(fld)
-    print contents
+    print(contents)
 
     for c in contents:
 

--- a/tests/test_msautotest.py
+++ b/tests/test_msautotest.py
@@ -25,7 +25,7 @@ def create_image_from_map(map_file, dll_location):
     with p.stdout:
         print(map_file)
         for line in iter(p.stdout.readline, b''):
-            print(line,)
+            print(line)
 
     p.wait() # wait for the subprocess to exit
 

--- a/tests/test_ordereddict.py
+++ b/tests/test_ordereddict.py
@@ -7,7 +7,7 @@ def test_dict():
     d = DefaultOrderedDict()
     d["key"] = ["value"]
 
-    print d["key"]
+    print(d["key"])
 
 def run_tests():        
     #pytest.main(["tests/test_ordereddict.py::test_dict"])

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -11,7 +11,7 @@ def test_all_maps():
     p = Parser(expand_includes=False)
 
     for fn in os.listdir(sample_dir):
-        print fn
+        print(fn)
         try:
             ast = p.parse_file(os.path.join(sample_dir, fn))
             #ast.to_png_with_pydot(r'C:\Temp\Trees\%s.png' % os.path.basename(fn))

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -242,7 +242,7 @@ def test_class_expression1():
     '''
     exp = "CLASS TEXT ([area]) END"
     print(output(s))
-    print exp
+    print(exp)
     assert(output(s) == exp)
 
 def test_class_expression2():
@@ -256,7 +256,7 @@ def test_class_expression2():
     '''
     exp = 'CLASS TEXT ("[area]") END'
     print(output(s))
-    print exp
+    print(exp)
     assert(output(s) == exp)
 
 def test_complex_class_expression():

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -67,6 +67,8 @@ def test_style_pattern2():
     exp = "STYLE PATTERN 5 5 END END"
     assert(output(s) == exp)
 
+
+@pytest.mark.xfail
 def test_style_pattern3():
     """
     This type of string fails
@@ -75,6 +77,8 @@ def test_style_pattern3():
     exp = "STYLE PATTERN 5 5 END END"
     assert(output(s) == exp)
 
+
+@pytest.mark.xfail
 def test_style_pattern4():
     """
     Fails
@@ -97,6 +101,8 @@ def test_style_pattern4():
     exp = "STYLE PATTERN 5.0 5.0 END END"
     assert(output(s) == exp)
 
+
+@pytest.mark.xfail
 def test_metadata():
     """
     Cannot parse metadata directly
@@ -366,6 +372,8 @@ def test_config_directive():
     exp = "MAP NAME 'ConfigMap' config MS_ERRORFILE 'stderr' config 'PROJ_DEBUG' 'OFF' config 'ON_MISSING_DATA' 'IGNORE' END"
     assert(output(s) == exp)
 
+
+@pytest.mark.xfail
 def test_multiple_composites():
     """
     UnexpectedToken: Unexpected token Token(__CLASS9, 'CLASS') at line 5, column 5.

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -18,7 +18,7 @@ def test_processing_directive():
     t = MapfileToDict()
     d = t.transform(ast)
 
-    print d
+    print(d)
 
     assert(len(d["processing"]) == 3)
 
@@ -39,7 +39,7 @@ def test_config_directive():
     t = MapfileToDict()
     d = t.transform(ast)
 
-    print d
+    print(d)
 
     assert(len(d["config"]) == 3)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py27,py37
-#pypy
+envlist = py27,py35,py36
 
 [testenv]
-deps=dev-requirements.txt
+deps=-rrequirements-dev.txt
 commands=py.test


### PR DESCRIPTION
I provide some fixes in order to make this library compatible with Python3. I also:

- corrected the tox.ini file so I could run tests with the `tox` command
- mark some tests as xfail since from comments in them, I understood that they can't pass yet.

Some tests are still failing on Python 2 and 3. Since I don't know wether this is expected, I didn't mark them as xfail.

Would you be interested in enabling travis-ci on this project? If so, I can provide a PR for that. I probably should wait for all the tests to pass or mark the failing ones as xfail.