### PR TITLE
Add a way to find all layers matching an attribute

### DIFF
--- a/docs/examples/search.py
+++ b/docs/examples/search.py
@@ -1,0 +1,11 @@
+import mappyfile
+
+# load will accept a filename (loads will accept a string)
+mapfile = mappyfile.load("./docs/examples/raster.map")
+
+# Search of a layer by its name
+mappyfile.find(mapfile['layers'], 'name', 'my_layer')
+       
+# Search for all layers of a group
+for layer in mappyfile.findall(mapfile['layers'], 'group', 'my_group'):
+    print(layer['name'])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,12 @@ Accessing Values
 
 .. literalinclude:: examples/accessing_values.py
    :language: python
+
+Query
++++++
+
+.. literalinclude:: examples/search.py
+   :language: python
   
 Modifying Values
 ++++++++++++++++

--- a/mappyfile/__init__.py
+++ b/mappyfile/__init__.py
@@ -1,2 +1,2 @@
 # allow high-level functions to be accessed directly from the mappyfile module
-from mappyfile.utils import load, loads, find, dumps, write
+from mappyfile.utils import load, loads, find, findall, dumps, write

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -50,6 +50,11 @@ def find(lst, key, value):
 def __find__(lst, key, value):
     return next((item for item in lst if item[key.lower()] == value), None)
 
+def findall(lst, key, value):
+    possible_values = ("'%s'" % value, '"%s"' % value)
+
+    return (item for item in lst if item[key.lower()] in possible_values)
+
 def _save(output_file, map_string):
 
     with codecs.open(output_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
- Add a findall method that returns an iterator. This method can be used
  to find all layers with an attribute that match the given value.
- Export it in __init__.py to make it easily accesible
- Document the querying of mapfiles.