### PR TITLE
Add support for relative path for nested include

### DIFF
--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -1,6 +1,6 @@
 import os, logging
 from io import open
-from lark import Lark, ParseError
+from lark import Lark
 import re
 
 try:
@@ -9,52 +9,54 @@ except ImportError:
     # Python3
     from io import StringIO
 
+
 class Parser(object):
 
-    def __init__(self, cwd="", expand_includes=True, add_linebreaks=True):
-        self.cwd = cwd
+    def __init__(self, expand_includes=True, add_linebreaks=True):
         self.expand_includes = expand_includes
         self.add_linebreaks = add_linebreaks
         self.g = self.load_grammar("mapfile.g")
+        self._nested_include = 0
 
-        
     def load_grammar(self, grammar_file):
-
         gf = os.path.join(os.path.dirname(__file__), grammar_file)
         grammar_text = open(gf).read()
+        return Lark(grammar_text, parser="earley", lexer="standard")
 
-        return Lark(grammar_text, parser='earley', lexer='standard')
-
-    def strip_quotes(self, s):
+    def _strip_quotes(self, s):
+        s = s[:s.index('#')] if '#' in s else s
         return s.strip("'").strip('"')
 
-    def load_includes(self, text):
-
+    def load_includes(self, text, fn=None):
+        # Per default use working directory of the process
+        if fn is None:
+            fn = os.getcwd()
         lines = text.split('\n')
         includes = {}
-
+        include_discovered = False
         for idx, l in enumerate(lines):
-            if l.strip().lower().startswith('include'):
-                if '#' in l:
-                    l = l[:l.index('#')]
+            if l.strip().lower().startswith("include"):
+                if not include_discovered:
+                    include_discovered = True
+                    self._nested_include += 1
+                if self._nested_include > 5:
+                    raise Exception("Maximum nested include exceeded! (MaxNested=5)")
 
-                parts = [p for p in l.split()]
-
-                assert (len(parts) == 2)
-                assert (parts[0].lower() == 'include')
-                fn = os.path.join(self.cwd, self.strip_quotes(parts[1]))
+                inc, inc_file_path = l.split()
+                inc_file_path = self._strip_quotes(inc_file_path)
+                if not os.path.isabs(inc_file_path):
+                    inc_file_path = os.path.join(os.path.dirname(fn), inc_file_path)
                 try:
-                    include_text = self.open_file(fn)
+                    include_text = self.open_file(inc_file_path)
                 except IOError as ex:
-                    logging.warning("Include file '%s' not found", fn)
+                    logging.warning("Include file '%s' not found", inc_file_path)
                     raise ex
                 # recursively load any further includes
-                includes[idx] = self.load_includes(include_text)
-    
+                includes[idx] = self.load_includes(include_text, fn=inc_file_path)
+
         for idx, txt in includes.items():
             lines.pop(idx) # remove the original include
             lines.insert(idx, txt)
-
         return '\n'.join(lines)
 
     def open_file(self, fn):
@@ -66,11 +68,9 @@ class Parser(object):
             raise
 
     def parse_file(self, fn):
-
-        self.cwd = os.path.dirname(fn)
-
+        self._nested_include = 0
         text = self.open_file(fn)
-        return self.parse(text)
+        return self.parse(text, fn=fn)
 
     def _add_linebreaks(self, text):
         """
@@ -87,10 +87,10 @@ class Parser(object):
 
         return "\n".join(new_lines)
 
-    def parse(self, text):
-
+    def parse(self, text, fn=None):
+        self._nested_include = 0
         if self.expand_includes == True:
-            text = self.load_includes(text)
+            text = self.load_includes(text, fn=fn)
 
         if self.add_linebreaks:
             text = self._add_linebreaks(text)

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -94,7 +94,7 @@ class Parser(object):
 
     def parse(self, text, fn=None):
         self._nested_include = 0
-        if self.expand_includes == True:
+        if self.expand_includes:
             text = self.load_includes(text, fn=fn)
 
         if self.add_linebreaks:

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -3,36 +3,36 @@ from mappyfile.transformer import MapfileToDict
 from mappyfile.pprint import PrettyPrinter
 import codecs
 
-def load(fn, cwd=None):
 
-    p = Parser(cwd=cwd)
+def load(fn, expand_includes=True, add_linebreaks=True):
+    p = Parser(expand_includes=expand_includes, add_linebreaks=add_linebreaks)
     ast = p.parse_file(fn)
     m = MapfileToDict()
     d = m.transform(ast)
+    return d
 
-    return d    
 
-def loads(s, cwd="", expand_includes=True):
-    p = Parser(cwd=cwd, expand_includes=expand_includes)
+def loads(s, expand_includes=True, add_linebreaks=True):
+    p = Parser(expand_includes=expand_includes, add_linebreaks=add_linebreaks)
     ast = p.parse(s)
     m = MapfileToDict()
     d = m.transform(ast)
+    return d
 
-    return d   
 
 def write(d, output_file, indent=4):
-
     map_string = _pprint(d, indent)
     _save(output_file, map_string)
-
     return output_file
+
 
 def dumps(d):
     return _pprint(d)
 
+
 def find(lst, key, value):
     """
-    When looking for an item by value also check for the value 
+    When looking for an item by value also check for the value
     surrounded by apostrophes
     """
     obj = __find__(lst, key, value)
@@ -47,18 +47,20 @@ def find(lst, key, value):
 
     return obj
 
+
 def __find__(lst, key, value):
     return next((item for item in lst if item[key.lower()] == value), None)
 
+
 def findall(lst, key, value):
     possible_values = ("'%s'" % value, '"%s"' % value)
-
     return (item for item in lst if item[key.lower()] in possible_values)
 
-def _save(output_file, map_string):
 
+def _save(output_file, map_string):
     with codecs.open(output_file, "w", encoding="utf-8") as f:
         f.write(map_string)
+
 
 def _pprint(d, indent=4):
     pp = PrettyPrinter(indent=indent)

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -3,6 +3,7 @@ from mappyfile.transformer import MapfileToDict
 from mappyfile.pprint import PrettyPrinter
 import codecs
 
+
 def load(fn, expand_includes=True, add_linebreaks=True):
     p = Parser(expand_includes=expand_includes, add_linebreaks=add_linebreaks)
     ast = p.parse_file(fn)
@@ -10,12 +11,14 @@ def load(fn, expand_includes=True, add_linebreaks=True):
     d = m.transform(ast)
     return d
 
+
 def loads(s, expand_includes=True, add_linebreaks=True):
     p = Parser(expand_includes=expand_includes, add_linebreaks=add_linebreaks)
     ast = p.parse(s)
     m = MapfileToDict()
     d = m.transform(ast)
     return d
+
 
 def write(d, output_file, indent=4):
     map_string = _pprint(d, indent)

--- a/tests/samples/include1_nested_path.map
+++ b/tests/samples/include1_nested_path.map
@@ -1,0 +1,4 @@
+MAP
+    NAME 'include_test'
+    INCLUDE 'mapfile_include/include2_nested_path.map'
+END

--- a/tests/samples/mapfile_include/include/include3_nested_path.map
+++ b/tests/samples/mapfile_include/include/include3_nested_path.map
@@ -1,0 +1,1 @@
+NAME 'test'

--- a/tests/samples/mapfile_include/include2_nested_path.map
+++ b/tests/samples/mapfile_include/include2_nested_path.map
@@ -1,0 +1,4 @@
+LAYER
+    NAME 'include_test'
+    INCLUDE 'include/include3_nested_path.map'
+END

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -21,14 +21,25 @@ def test_all_maps():
 
 def test_includes():
     p = Parser()
-   
+
     ast = p.parse_file('./tests/samples/include1.map')
     m = MapfileToDict()
 
     d = (m.transform(ast)) # works
     print(mappyfile.dumps(d))
 
-def run_tests():        
+
+def test_includes_nested_path():
+    p = Parser()
+
+    ast = p.parse_file('./tests/samples/include1_nested_path.map')
+    m = MapfileToDict()
+
+    d = (m.transform(ast)) # works
+    print(mappyfile.dumps(d))
+
+
+def run_tests():
     pytest.main(["tests/test_sample_maps.py"])
 
 if __name__ == '__main__':

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -37,7 +37,7 @@ def test_includes_nested_path():
     ast = p.parse_file('./tests/samples/include1_nested_path.map')
     m = MapfileToDict()
 
-    d = (m.transform(ast)) # works
+    d = (m.transform(ast)) #  works
     print(mappyfile.dumps(d))
 
 

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -27,7 +27,7 @@ def test_includes():
     ast = p.parse_file('./tests/samples/include1.map')
     m = MapfileToDict()
 
-    d = (m.transform(ast))  # works
+    d = (m.transform(ast))  #  works
     print(mappyfile.dumps(d))
 
 
@@ -49,3 +49,4 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     test_all_maps()
     print("Done!")
+    


### PR DESCRIPTION
Not sure what you tried to accomplish with cwd, append absolute paths?

According to me in mapfile you have either
- relative paths
- absolute paths

It seems that it was overriden every time when calling `parse_file`, which is not something I'd expect and I couldn't find any test for cwd argument.

Hope that you are happy with these changes.

In the utils section I added all the options you can give the parser (namely `add_linebreaks` for `loads` and `expand_includes` + `add_linebreaks` for `load`)

DOC:
http://mapserver.org/mapfile/include.html

```
Supported in versions 4.10 and higher.

The name of the file to be included MUST be quoted (single or double quotes).

Includes may be nested, up to 5 deep.

File location can be given as a full path to the file, or (in MapServer >= 4.10.1) as a path relative to the mapfile.
```