### PR TITLE
Flake8

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source=mappyfile

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cache
 /.eggs
 /.vs/config
 /.venv
+/.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,9 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-install: pip install tox-travis
-script: tox
+install:
+    - pip install tox-travis flake8
+script:
+    - tox
+    - flake8 mappyfile
+    - flake8 --ignore=E501 tests

--- a/mappyfile/__init__.py
+++ b/mappyfile/__init__.py
@@ -2,3 +2,5 @@
 from mappyfile.utils import load, loads, find, findall, dumps, write
 
 __version__ = "0.3.2"
+
+__all__ = ['load', 'loads', 'find', 'findall', 'dumps', 'write']

--- a/mappyfile/ordereddict.py
+++ b/mappyfile/ordereddict.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict, Callable
 
+
 class DefaultOrderedDict(OrderedDict):
     # Source: http://stackoverflow.com/a/6190500/562769
     # http://code.activestate.com/recipes/523034-emulate-collectionsdefaultdict/
     def __init__(self, default_factory=None, *a, **kw):
         if (default_factory is not None and
-           not isinstance(default_factory, Callable)):
+                not isinstance(default_factory, Callable)):
             raise TypeError('first argument must be callable')
         OrderedDict.__init__(self, *a, **kw)
         self.default_factory = default_factory

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -1,6 +1,7 @@
-import os, logging
+import os
+import logging
 from io import open
-from lark import Lark, ParseError
+from lark import Lark
 import re
 
 try:
@@ -8,6 +9,7 @@ try:
 except ImportError:
     # Python3
     from io import StringIO
+
 
 class Parser(object):
 
@@ -17,7 +19,6 @@ class Parser(object):
         self.add_linebreaks = add_linebreaks
         self.g = self.load_grammar("mapfile.g")
 
-        
     def load_grammar(self, grammar_file):
 
         gf = os.path.join(os.path.dirname(__file__), grammar_file)
@@ -50,19 +51,23 @@ class Parser(object):
                     raise ex
                 # recursively load any further includes
                 includes[idx] = self.load_includes(include_text)
-    
+
         for idx, txt in includes.items():
-            lines.pop(idx) # remove the original include
+            lines.pop(idx)  # remove the original include
             lines.insert(idx, txt)
 
         return '\n'.join(lines)
 
     def open_file(self, fn):
         try:
-            return open(fn, "r", encoding="utf-8").read() # specify Unicode for Python 2.7
+            # specify Unicode for Python 2.7
+            return open(fn, "r", encoding="utf-8").read()
         except UnicodeDecodeError as ex:
             logging.debug(ex)
-            logging.error("Please check the encoding for %s. All Mapfiles should be in utf-8 format. ", fn)
+            logging.error(
+                "Please check the encoding for %s. " +
+                "All Mapfiles should be in utf-8 format.",
+                fn)
             raise
 
     def parse_file(self, fn):
@@ -89,7 +94,7 @@ class Parser(object):
 
     def parse(self, text):
 
-        if self.expand_includes == True:
+        if self.expand_includes:
             text = self.load_includes(text)
 
         if self.add_linebreaks:

--- a/mappyfile/tokens.py
+++ b/mappyfile/tokens.py
@@ -102,7 +102,7 @@ COMPOSITE_NAMES = frozenset("""
     maxsubdivide
     maxtemplate
     maxwidth
-    
+
     mimetype
     minarcs
     minboxsize
@@ -184,9 +184,9 @@ COMPOSITE_NAMES = frozenset("""
     units
     utfdata
     utfitem
-    
-    
-    
+
+
+
     width
     wkt
     wrap

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -3,6 +3,7 @@ from mappyfile.transformer import MapfileToDict
 from mappyfile.pprint import PrettyPrinter
 import codecs
 
+
 def load(fn, cwd=None):
 
     p = Parser(cwd=cwd)
@@ -10,7 +11,8 @@ def load(fn, cwd=None):
     m = MapfileToDict()
     d = m.transform(ast)
 
-    return d    
+    return d
+
 
 def loads(s, cwd="", expand_includes=True):
     p = Parser(cwd=cwd, expand_includes=expand_includes)
@@ -18,7 +20,8 @@ def loads(s, cwd="", expand_includes=True):
     m = MapfileToDict()
     d = m.transform(ast)
 
-    return d   
+    return d
+
 
 def write(d, output_file, indent=4):
 
@@ -27,12 +30,14 @@ def write(d, output_file, indent=4):
 
     return output_file
 
+
 def dumps(d):
     return _pprint(d)
 
+
 def find(lst, key, value):
     """
-    When looking for an item by value also check for the value 
+    When looking for an item by value also check for the value
     surrounded by apostrophes
     """
     obj = __find__(lst, key, value)
@@ -47,18 +52,22 @@ def find(lst, key, value):
 
     return obj
 
+
 def __find__(lst, key, value):
     return next((item for item in lst if item[key.lower()] == value), None)
+
 
 def findall(lst, key, value):
     possible_values = ("'%s'" % value, '"%s"' % value)
 
     return (item for item in lst if item[key.lower()] in possible_values)
 
+
 def _save(output_file, map_string):
 
     with codecs.open(output_file, "w", encoding="utf-8") as f:
         f.write(map_string)
+
 
 def _pprint(d, indent=4):
     pp = PrettyPrinter(indent=indent)

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -3,9 +3,10 @@ import os
 import jsonschema
 import logging
 
+
 def get_schema(schema_name):
     """
-    Had to remove the id property from map.json or it uses URLs for validation    
+    Had to remove the id property from map.json or it uses URLs for validation
     See various issues at https://github.com/Julian/jsonschema/pull/306
     """
     schema_path = os.path.join(os.path.dirname(__file__), "schemas")
@@ -13,8 +14,10 @@ def get_schema(schema_name):
     assert(os.path.isfile(schema))
 
     # need to set a full file URI to the base schema
-    schema_path = "file:///{}".format(os.path.abspath(schema)).replace("\\","/")
+    schema_path = "file:///{}".format(os.path.abspath(schema)
+                                      ).replace("\\", "/")
     return schema_path, json.load(open(schema))
+
 
 def validate(d, schema_name="map.json"):
 
@@ -30,4 +33,3 @@ def validate(d, schema_name="map.json"):
         return False
 
     return True
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
 colorama==0.3.7
+docutils==0.13.1
+lark-parser==0.2.1
+pluggy==0.4.0
 py==1.4.32
 pydot==1.2.3
 pyparsing==2.1.10
 pytest==3.0.5
-pluggy==0.4.0
-pytest==3.0.5
 tox==2.5.0
 virtualenv==15.1.0
-lark-parser==0.2.1
-docutils==0.13.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ py==1.4.32
 pydot==1.2.3
 pyparsing==2.1.10
 pytest==3.0.5
+pytest-cov
 tox==2.5.0
 virtualenv==15.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 colorama==0.3.7
 docutils==0.13.1
+flake8==3.4.1
 lark-parser==0.2.1
 pluggy==0.4.0
 py==1.4.32

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,39 @@
 import re
 from setuptools import setup
 
-__version__,= re.findall('__version__ = "(.*)"', open('mappyfile/__init__.py').read())
+__version__, = re.findall('__version__ = "(.*)"',
+                          open('mappyfile/__init__.py').read())
+
 
 def readme():
     with open('README.rst') as f:
         return f.read()
+
 
 setup(name='mappyfile',
       version=__version__,
       description='A pure Python MapFile parser for working with MapServer',
       long_description=readme(),
       classifiers=[
-        # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Intended Audience :: Developers',
-        'Topic :: Text Processing :: Linguistic',
-        'Topic :: Software Development :: Build Tools'
+          # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+          'Development Status :: 3 - Alpha',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Intended Audience :: Developers',
+          'Topic :: Text Processing :: Linguistic',
+          'Topic :: Software Development :: Build Tools'
       ],
-      package_data = {
-        '': ['*.g', 'schemas/*.json']
+      package_data={
+          '': ['*.g', 'schemas/*.json']
       },
       url='http://github.com/geographika/mappyfile',
       author='Seth Girvin',
       author_email='sethg@geographika.co.uk',
       license='MIT',
       packages=['mappyfile'],
-      install_requires=['lark-parser','jsonschema'],
+      install_requires=['lark-parser', 'jsonschema'],
       zip_safe=False)

--- a/tests/test_large_file.py
+++ b/tests/test_large_file.py
@@ -1,8 +1,5 @@
-import os, logging
-import pytest
 from mappyfile.parser import Parser
 from mappyfile.pprint import PrettyPrinter
-import mappyfile
 from mappyfile.transformer import MapfileToDict
 
 import cProfile
@@ -10,21 +7,22 @@ import cProfile
 
 def output(fn):
     """
-    Parse, transform, and pretty print 
+    Parse, transform, and pretty print
     the result
     """
     p = Parser()
     m = MapfileToDict()
 
     ast = p.parse_file(fn)
-    #print(ast)
+    # print(ast)
     d = m.transform(ast)
-    #print(d)
+    # print(d)
     pp = PrettyPrinter(indent=0, newlinechar=" ", quote="'")
     pp.pprint(d)
 
+
 if __name__ == "__main__":
-    #fn = r"D:\Temp\large_map1.txt"
+    # fn = r"D:\Temp\large_map1.txt"
     fn = r"D:\Temp\large_map2.txt"
     pr = cProfile.Profile()
     pr.enable()

--- a/tests/test_msautotest.py
+++ b/tests/test_msautotest.py
@@ -2,18 +2,20 @@
 Parse all the test Mapfiles in msautotests, write them to a new file,
 and then test that these also parse correctly
 """
-import os, logging, glob, json, shutil
+import os
+import logging
+import glob
+import shutil
 
 from mappyfile.pprint import PrettyPrinter
 from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
-import pprint
 import mappyfile
+
 
 def create_copy(msautotest_fld, msautotest_copy):
 
     # first make a backup copy of msautotest
-
 
     if os.path.isdir(msautotest_copy):
         shutil.rmtree(msautotest_copy)
@@ -25,12 +27,13 @@ def create_copy(msautotest_fld, msautotest_copy):
 
     return msautotest_copy
 
+
 def parse_mapfile(parser, transformer, pp, fn):
     logging.debug("Parsing %s", fn)
 
     try:
         ast = parser.parse_file(fn)
-        #print(ast)
+        # print(ast)
     except Exception as ex:
         logging.warning("%s could not be successfully parsed", fn)
         logging.exception(ex)
@@ -42,15 +45,18 @@ def parse_mapfile(parser, transformer, pp, fn):
         logging.warning("%s could not be successfully transformed", fn)
         logging.exception(ex)
         raise
-        
-    #map_string = pp.pprint(d)
-    #print(map_string)
+
+    # map_string = pp.pprint(d)
+    # print(map_string)
 
     return d
 
+
 def main(msautotest_fld, create_new_copy=True):
 
-    msautotest_copy = os.path.join(os.path.dirname(msautotest_fld), "msautotest_mappyfile")
+    msautotest_copy = os.path.join(
+        os.path.dirname(msautotest_fld),
+        "msautotest_mappyfile")
 
     if create_new_copy:
         create_copy(msautotest_fld, msautotest_copy)
@@ -59,21 +65,23 @@ def main(msautotest_fld, create_new_copy=True):
     transformer = MapfileToDict()
     pp = PrettyPrinter()
 
-    # these two maps aren't in utf8, see https://github.com/mapserver/mapserver/pull/5460
-    #ignore_list = ["wms_inspire_scenario1.map","wms_inspire_scenario2.map"] 
+    # these two maps aren't in utf8
+    # see https://github.com/mapserver/mapserver/pull/5460
+    # ignore_list = ["wms_inspire_scenario1.map","wms_inspire_scenario2.map"]
     ignore_list = []
 
     mapfiles = glob.glob(msautotest_fld + '/**/*.map')
     mapfiles = [f for f in mapfiles if os.path.basename(f) not in ignore_list]
-    
+
     for fn in mapfiles:
 
         d = parse_mapfile(parser, transformer, pp, fn)
         output_file = fn.replace(msautotest_fld, msautotest_copy)
-        mf = mappyfile.utils.write(d, output_file)
+        mappyfile.utils.write(d, output_file)
 
         # now try reading it again
         d = parse_mapfile(parser, transformer, pp, output_file)
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_ordereddict.py
+++ b/tests/test_ordereddict.py
@@ -2,6 +2,7 @@ import pytest
 
 from mappyfile.ordereddict import DefaultOrderedDict
 
+
 def test_dict():
 
     d = DefaultOrderedDict()
@@ -9,10 +10,12 @@ def test_dict():
 
     print(d["key"])
 
-def run_tests():        
-    #pytest.main(["tests/test_ordereddict.py::test_dict"])
+
+def run_tests():
+    # pytest.main(["tests/test_ordereddict.py::test_dict"])
     pytest.main(["tests/test_ordereddict.py"])
+
 
 if __name__ == '__main__':
     run_tests()
-    #test_dict()
+    # test_dict()

--- a/tests/test_pprint.py
+++ b/tests/test_pprint.py
@@ -3,10 +3,11 @@ import pytest
 from mappyfile.pprint import PrettyPrinter
 import mappyfile
 
+
 def test_nested_quotes():
     """
     If values contain quotes then make sure they are escaped
-    shp2img -m C:\Temp\msautotest\misc\ogr_vrtconnect.tmp.map    
+    shp2img -m C:\Temp\msautotest\misc\ogr_vrtconnect.tmp.map
     """
     s = """
     LAYER
@@ -17,25 +18,27 @@ def test_nested_quotes():
     END"""
 
     ast = mappyfile.loads(s)
-    pp = PrettyPrinter(indent=0, quote='"', newlinechar=" ") # expected
+    pp = PrettyPrinter(indent=0, quote='"', newlinechar=" ")  # expected
     res = pp.pprint(ast)
     exp = r'LAYER NAME shppoly TYPE polygon CONNECTIONTYPE OGR CONNECTION "<OGRVRTDataSource><OGRVRTLayer name=\"poly\">' \
         r'<SrcDataSource relativeToVRT=\"0\">data/shppoly</SrcDataSource><SrcLayer>poly</SrcLayer></OGRVRTLayer></OGRVRTDataSource>" END'
     assert(res == exp)
 
+
 def test_standardise_quotes():
 
     v = '"the_geom from (select * from road where "name_e"=\'Trans-Canada Highway\' order by gid) as foo using unique gid using srid=3978"'
 
-    pp = PrettyPrinter(indent=0, quote='"', newlinechar=" ") # expected
+    pp = PrettyPrinter(indent=0, quote='"', newlinechar=" ")  # expected
     v2 = pp.standardise_quotes(v)
     exp = r'''"the_geom from (select * from road where \"name_e\"='Trans-Canada Highway' order by gid) as foo using unique gid using srid=3978"'''
     assert(v2 == exp)
 
-    pp = PrettyPrinter(indent=0, quote="'", newlinechar=" ") # expected
+    pp = PrettyPrinter(indent=0, quote="'", newlinechar=" ")  # expected
     v2 = pp.standardise_quotes(v)
     exp = r"""'the_geom from (select * from road where "name_e"=\'Trans-Canada Highway\' order by gid) as foo using unique gid using srid=3978'"""
     assert(v2 == exp)
+
 
 def test_double_attributes():
 
@@ -47,10 +50,11 @@ def test_double_attributes():
 
     s = 'MAP CONFIG "MS_ERRORFILE" "stderr" END'
     ast = mappyfile.loads(s)
-    pp = PrettyPrinter(indent=0, quote="'", newlinechar=" ") # expected
+    pp = PrettyPrinter(indent=0, quote="'", newlinechar=" ")  # expected
     res = pp.pprint(ast)
     assert(res == "MAP CONFIG 'MS_ERRORFILE' 'stderr' END")
-        
+
+
 def test_already_escaped():
     """
     Don't escape an already escaped quote
@@ -68,6 +72,7 @@ def test_already_escaped():
     res = pp.pprint(ast)
     exp = r"CLASS EXPRESSION '\'Tignish' END"
     assert(res == exp)
+
 
 def test_format_list():
 
@@ -88,8 +93,8 @@ def test_format_list():
         END
     """
 
-    ast = mappyfile.loads(s)
-    pp = PrettyPrinter(indent=0) # expected
+    mappyfile.loads(s)
+    pp = PrettyPrinter(indent=0)  # expected
 
     k = "pattern"
     lst = [[5, 5, 10, 10]]
@@ -98,6 +103,7 @@ def test_format_list():
     r = pp.process_list(k, lst, 0)
     exp = [u'PATTERN', '5 5\n10 10', u'END']
     assert(r == exp)
+
 
 def test_unicode():
 
@@ -114,6 +120,7 @@ def test_unicode():
     exp = u"MAP METADATA 'ows_title' 'éúáí' END END"
     assert(res == exp)
 
+
 def test_config():
 
     s = """
@@ -124,15 +131,17 @@ def test_config():
     ast = mappyfile.loads(s)
     pp = PrettyPrinter(indent=0, quote="'", newlinechar=" ")
     res = pp.pprint(ast)
-    #print(res)
+    # print(res)
     exp = u"MAP CONFIG 'MS_ERRORFILE' 'my.log' END"
     assert(res == exp)
 
-def run_tests():        
-    #pytest.main(["tests/test_pprint.py::test_format_list"])
+
+def run_tests():
+    # pytest.main(["tests/test_pprint.py::test_format_list"])
     pytest.main(["tests/test_pprint.py"])
+
 
 if __name__ == "__main__":
     run_tests()
-    #test_double_attributes()
+    # test_double_attributes()
     print("Done!")

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -1,8 +1,10 @@
-import os, logging
+import os
+import logging
 import pytest
 import mappyfile
 from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
+
 
 def test_all_maps():
 
@@ -13,26 +15,28 @@ def test_all_maps():
     for fn in os.listdir(sample_dir):
         print(fn)
         try:
-            ast = p.parse_file(os.path.join(sample_dir, fn))
-            #ast.to_png_with_pydot(r'C:\Temp\Trees\%s.png' % os.path.basename(fn))
-        except:
+            p.parse_file(os.path.join(sample_dir, fn))
+        except BaseException:
             logging.warning("Cannot process %s ", fn)
             raise
 
+
 def test_includes():
     p = Parser()
-   
+
     ast = p.parse_file('./tests/samples/include1.map')
     m = MapfileToDict()
 
-    d = (m.transform(ast)) # works
+    d = (m.transform(ast))  # works
     print(mappyfile.dumps(d))
 
-def run_tests():        
+
+def run_tests():
     pytest.main(["tests/test_sample_maps.py"])
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     test_all_maps()
-    #run_tests()
+    # run_tests()
     print("Done!")

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -1,22 +1,22 @@
-import os, logging
+import logging
 import pytest
 from mappyfile.parser import Parser
 from mappyfile.pprint import PrettyPrinter
-import mappyfile
 from mappyfile.transformer import MapfileToDict
+
 
 def output(s):
     """
-    Parse, transform, and pretty print 
+    Parse, transform, and pretty print
     the result
     """
     p = Parser()
     m = MapfileToDict()
-    
+
     ast = p.parse(s)
-    #print(ast)
+    # print(ast)
     d = m.transform(ast)
-    #print(d)
+    # print(d)
     pp = PrettyPrinter(indent=0, newlinechar=" ", quote="'")
     return pp.pprint(d)
 
@@ -52,7 +52,7 @@ def test_style_pattern():
 
     s = """
     STYLE
-        PATTERN 5 5 END 
+        PATTERN 5 5 END
     END
     """
 
@@ -63,10 +63,10 @@ def test_style_pattern():
 def test_style_pattern2():
 
     s = """
-    STYLE 
-        PATTERN 
+    STYLE
+        PATTERN
             5 5
-        END 
+        END
     END
     """
 
@@ -88,15 +88,16 @@ def test_style_pattern4():
     Test pattern values on separate lines are valid
     """
     s = """
-    STYLE 
-        PATTERN 
+    STYLE
+        PATTERN
             5
-            5 
-        END 
+            5
+        END
     END
     """
     exp = "STYLE PATTERN 5 5 END END"
     assert(output(s) == exp)
+
 
 @pytest.mark.xfail
 def test_style_pattern5():
@@ -106,38 +107,41 @@ def test_style_pattern5():
     UnexpectedToken: Unexpected token Token(_END, 'END') at line 3, column 27.
     """
     s = """
-    STYLE 
+    STYLE
         PATTERN 6 4 2 4 6 END
     END
     """
     exp = "STYLE PATTERN 6 4 2 4 6 END END"
     assert(output(s) == exp)
 
+
 def test_metadata():
     """
     Parse metadata directly
     """
     s = """
-    METADATA 
+    METADATA
         'wms_title' 'Test simple wms'
     END
     """
     exp = """METADATA 'wms_title' 'Test simple wms' END"""
     assert(output(s) == exp)
 
+
 def test_metadata_unquoted():
     """
-    The METADATA block doesn't need quotes 
+    The METADATA block doesn't need quotes
     (as long as values don't have spaces)
     """
     s = """
-    METADATA 
+    METADATA
         wms_title my_title
     END
     """
     exp = """METADATA wms_title my_title END"""
-    #print output(s)
+    # print output(s)
     assert(output(s) == exp)
+
 
 def test_validation():
     """
@@ -149,9 +153,10 @@ def test_validation():
         "field2" "-1"
     END
     """
-    #print output(s)
+    # print output(s)
     exp = """VALIDATION 'field1' '^[0-9,]+$' 'field2' '-1' END"""
     assert(output(s) == exp)
+
 
 def test_layer_text_query():
     s = """
@@ -172,8 +177,8 @@ def test_label():
       SIZE 8
       POSITION AUTO
       PARTIALS FALSE
-      OUTLINECOLOR 255 255 255			
-    END 
+      OUTLINECOLOR 255 255 255
+    END
     """
     exp = "LABEL COLOR 0 0 0 FONT Vera TYPE truetype SIZE 8 POSITION AUTO PARTIALS FALSE OUTLINECOLOR 255 255 255 END"
     assert(output(s) == exp)
@@ -241,7 +246,7 @@ def test_feature():
     """
 
     s = """
-        LAYER        
+        LAYER
             FEATURE
                 POINTS
                     0 10
@@ -311,7 +316,7 @@ def test_complex_class_expression():
     CLASS
       TEXT ("Area is: " + tostring([area],"%.2f"))
     END
-    '''         
+    '''
     exp = '''CLASS TEXT ("Area is: " + (tostring([area],"%.2f"))) END'''
     assert(output(s) == exp)
 
@@ -391,7 +396,7 @@ def test_processing_directive():
     END
     """
 
-    #print(output(s))
+    # print(output(s))
     exp = "LAYER NAME 'ProcessingLayer' PROCESSING 'BANDS=1' PROCESSING 'CONTOUR_ITEM=elevation' PROCESSING 'CONTOUR_INTERVAL=20' END"
     assert(output(s) == exp)
 
@@ -410,6 +415,7 @@ def test_config_directive():
     exp = "MAP NAME 'ConfigMap' CONFIG MS_ERRORFILE 'stderr' CONFIG 'PROJ_DEBUG' 'OFF' CONFIG 'ON_MISSING_DATA' 'IGNORE' END"
     assert(output(s) == exp)
 
+
 def test_multiple_composites():
     """
     Allow for multiple root composites
@@ -426,6 +432,7 @@ def test_multiple_composites():
     """
     exp = "CLASS NAME 'Name1' END CLASS NAME 'Name2' END"
     assert(output(s) == exp)
+
 
 def test_map():
     s = """
@@ -456,6 +463,7 @@ def test_oneline_composites():
     exp = ' '.join(s.split())
     assert(output(s) == exp)
 
+
 def test_querymap():
 
     s = """
@@ -468,11 +476,12 @@ def test_querymap():
          END
     END
     """
-    #print output(s)
+    # print output(s)
     exp = "MAP QUERYMAP COLOR 255 255 0 SIZE -1 -1 STATUS OFF STYLE HILITE END END"
     assert(output(s) == exp)
 
-def test_output_format():
+
+def test_output_format_esri():
 
     s = """
     OUTPUTFORMAT
@@ -484,6 +493,7 @@ def test_output_format():
     """
     exp = "OUTPUTFORMAT NAME 'shapezip' DRIVER 'OGR/ESRI Shapefile' TRANSPARENT FALSE IMAGEMODE FEATURE END"
     assert(output(s) == exp)
+
 
 def test_auto_projection():
     """
@@ -498,18 +508,20 @@ def test_auto_projection():
     END
     """
     exp = "MAP PROJECTION AUTO END END"
-    #print(output(s))
+    # print(output(s))
     assert(output(s) == exp)
+
 
 def test_runtime_expression():
     s = """
     CLASS
-      EXPRESSION ( [EPPL_Q100_] = %eppl% )		   
+      EXPRESSION ( [EPPL_Q100_] = %eppl% )
     END
     """
     exp = "CLASS EXPRESSION (( [EPPL_Q100_] = %eppl% )) END"
-    #print(output(s))
+    # print(output(s))
     assert(output(s) == exp)
+
 
 def test_mutliple_output_formats():
     """
@@ -524,6 +536,7 @@ def test_mutliple_output_formats():
     exp = "OUTPUTFORMAT FORMATOPTION 'FORM=zip' FORMATOPTION 'SPATIAL_INDEX=YES' END"
     assert(output(s) == exp)
 
+
 def test_config_case():
     """
     https://github.com/geographika/mappyfile/issues/18
@@ -531,16 +544,17 @@ def test_config_case():
 
     s = """
     MAP
-	    CONFIG "PROJ_LIB" "projections"
+        CONFIG "PROJ_LIB" "projections"
     END
     """
     exp = "MAP CONFIG 'PROJ_LIB' 'projections' END"
     assert(output(s) == exp)
 
+
 def test_ne_comparison():
     """
     IS NOT is not valid
-    NE (Not Equals) should be used instead 
+    NE (Not Equals) should be used instead
     """
     s = """
     CLASS
@@ -550,6 +564,7 @@ def test_ne_comparison():
     """
     exp = 'CLASS EXPRESSION (( "[building]" NE NULL )) END'
     assert(output(s) == exp)
+
 
 def test_eq_comparison():
     """
@@ -561,8 +576,9 @@ def test_eq_comparison():
     END
     """
     exp = 'CLASS EXPRESSION (( "[building]" eq NULL )) END'
-    #print(output(s))
+    # print(output(s))
     assert(output(s) == exp)
+
 
 def test_no_linebreaks():
     """
@@ -572,12 +588,14 @@ def test_no_linebreaks():
     exp = "CLASS NAME 'Test' STYLE OUTLINECOLOR 0 0 0 END END"
     assert(output(s) == exp)
 
-def run_tests():        
-    #pytest.main(["tests/test_snippets.py::test_style_pattern"])
+
+def run_tests():
+    # pytest.main(["tests/test_snippets.py::test_style_pattern"])
     pytest.main(["tests/test_snippets.py"])
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    #test_no_linebreaks()
+    # test_no_linebreaks()
     run_tests()
     print("Done!")

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -2,6 +2,7 @@ import pytest
 from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
 
+
 def test_processing_directive():
 
     s = """
@@ -18,6 +19,7 @@ def test_processing_directive():
     t = MapfileToDict()
     d = t.transform(ast)
     assert(len(d["processing"]) == 3)
+
 
 def test_config_directive():
 
@@ -36,12 +38,13 @@ def test_config_directive():
     d = t.transform(ast)
     assert(len(d["config"]) == 3)
 
+
 def test_metadata():
 
     s = """
     MAP
         METADATA
-            'wms_enable_request'  '*'     
+            'wms_enable_request'  '*'
         END
     END
     """
@@ -50,14 +53,16 @@ def test_metadata():
     ast = p.parse(s)
     t = MapfileToDict()
     d = t.transform(ast)
-    #print(dict(d["metadata"]))
+    # print(dict(d["metadata"]))
     assert(d["metadata"]["'wms_enable_request'"] == "'*'")
 
-def run_tests():        
-    #pytest.main(["tests/test_transformer.py::test_config_directive"])
+
+def run_tests():
+    # pytest.main(["tests/test_transformer.py::test_config_directive"])
     pytest.main(["tests/test_transformer.py"])
 
+
 if __name__ == '__main__':
-    #run_tests()
+    # run_tests()
     test_metadata()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,9 +1,9 @@
 import os
 import logging
 import mappyfile
+# from mappyfile import validator
 from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
-from mappyfile import validator
 from subprocess import Popen, PIPE, STDOUT
 
 DLL_LOCATION = r"C:\MapServer\bin"
@@ -111,9 +111,12 @@ def main():
     print(d)
     # s = schema["definitions"]["map"]["properties"]["status"]
 
-    # if validator.validate(d):
-        # name = "test"
-        # create_image(name, d, output_folder=output_folder)
+    """
+    if validator.validate(d):
+        name = "test"
+        output_folder = r"D:\Temp"
+        create_image(name, d, output_folder=output_folder)
+    """
 
 
 if __name__ == "__main__":

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,15 +1,13 @@
-import os, logging
-import pytest
-from mappyfile.parser import Parser
-from mappyfile.pprint import PrettyPrinter
+import os
+import logging
 import mappyfile
+from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
 from mappyfile import validator
-import os
 from subprocess import Popen, PIPE, STDOUT
-import mappyfile
 
 DLL_LOCATION = r"C:\MapServer\bin"
+
 
 def create_image(name, mapfile, output_folder, format="png"):
 
@@ -20,11 +18,22 @@ def create_image(name, mapfile, output_folder, format="png"):
 
     return _create_image_from_map(out_map, out_img, format=format)
 
+
 def _create_image_from_map(map_file, out_img, format):
 
     out_img += ".%s" % format
 
-    params = ["shp2img", "-m", map_file, "-i", format, "-o", out_img, "-s", 256, 256] # ,  # "-e", "0 0 5 5"
+    params = [
+        "shp2img",
+        "-m",
+        map_file,
+        "-i",
+        format,
+        "-o",
+        out_img,
+        "-s",
+        256,
+        256]  # ,  # "-e", "0 0 5 5"
     params = [str(p) for p in params]
     logging.info(" ".join(params))
 
@@ -38,7 +47,7 @@ def _create_image_from_map(map_file, out_img, format):
         for line in iter(p.stdout.readline, b''):
             errors.append(line)
 
-    exitcode = p.wait() # wait for the subprocess to exit
+    p.wait()  # wait for the subprocess to exit
 
     if errors:
         logging.error("\n".join(errors))
@@ -48,6 +57,7 @@ def _create_image_from_map(map_file, out_img, format):
         os.startfile(out_img)
 
     return out_img
+
 
 def main():
     s = """
@@ -89,25 +99,23 @@ def main():
 
     p = Parser()
     m = MapfileToDict()
-    
+
     ast = p.parse(s)
     d = m.transform(ast)
- 
+
     # test a value passed in from the editor
-    d["status"] = "OFF" # need to convert to uppercase if not already?
-    v = d["status"]
-    
-    #d["layers"][0]["type"] = "POINTX"
+    d["status"] = "OFF"  # need to convert to uppercase if not already?
+
+    # d["layers"][0]["type"] = "POINTX"
 
     print(d)
-    #s = schema["definitions"]["map"]["properties"]["status"]
+    # s = schema["definitions"]["map"]["properties"]["status"]
 
-    if validator.validate(d):
-        output_folder = r"D:\Temp"
-        name = "test"
+    # if validator.validate(d):
+        # name = "test"
+        # create_image(name, d, output_folder=output_folder)
 
-        #create_image(name, d, output_folder=output_folder)
-   
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,8 @@
 envlist = py27,py35,py36
 
 [testenv]
+# necessary to make cov find the .coverage file
+# see http://blog.ionelmc.ro/2014/05/25/python-packaging/
+usedevelop = true
 deps=-rrequirements-dev.txt
-commands=py.test
+commands=py.test --cov mappyfile docs/examples/api/ misc/ tests/


### PR DESCRIPTION
Fix for https://github.com/geographika/mappyfile/issues/29

I using the default flake8 command to fix the errors.

In the tests I am ignoring line length, as we can have some long mapfile strings.

I fixed most of the errors using autopep8.

A useful command:
`autopep8 --in-place --aggressive --aggressive --verbose $(find mappyfile/* -type f -name "*.py" -print)`