### PR TITLE
Enable the parsing of non-ascii chars

### DIFF
--- a/mappyfile/transformer.py
+++ b/mappyfile/transformer.py
@@ -3,12 +3,18 @@ Module to transform an AST (Abstract Syntax Tree) to a
 Python dict structure
 """
 
+import sys
 from collections import OrderedDict
 from lark import Transformer, Tree
 from mappyfile.tokens import COMPOSITE_NAMES, SINGLETON_COMPOSITE_NAMES
 from mappyfile.tokens import REPEATED_KEYS
 from mappyfile.ordereddict import DefaultOrderedDict, CaseInsensitveOrderedDict
 from mappyfile.pprint import Quoter
+
+
+PY3 = sys.version_info[0] == 3
+if not PY3:
+    str = unicode # NOQA
 
 
 def plural(s):

--- a/mappyfile/transformer.py
+++ b/mappyfile/transformer.py
@@ -12,8 +12,8 @@ from mappyfile.ordereddict import DefaultOrderedDict, CaseInsensitveOrderedDict
 from mappyfile.pprint import Quoter
 
 
-PY3 = sys.version_info[0] == 3
-if not PY3:
+PY2 = sys.version_info[0] < 3
+if PY2:
     str = unicode # NOQA
 
 


### PR DESCRIPTION
Otherwise you can't put `ü` and so on in expressions in py2.