### PR TITLE
fix windows cwd name issue in includes

### DIFF
--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -51,7 +51,7 @@ class Parser(object):
     def load_includes(self, text, fn=None, _nested_includes=0):
         # Per default use working directory of the process
         if fn is None:
-            fn = os.getcwd()+'/'  
+            fn = os.getcwd()+'/'
             # this stops windows eating the current dir
 
         lines = text.split('\n')

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -51,7 +51,9 @@ class Parser(object):
     def load_includes(self, text, fn=None, _nested_includes=0):
         # Per default use working directory of the process
         if fn is None:
-            fn = os.getcwd()+'/' #this stops windows eating the current dir
+            fn = os.getcwd()+'/'  
+            #this stops windows eating the current dir
+
         lines = text.split('\n')
         includes = {}
         for idx, l in enumerate(lines):

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -51,7 +51,7 @@ class Parser(object):
     def load_includes(self, text, fn=None, _nested_includes=0):
         # Per default use working directory of the process
         if fn is None:
-            fn = os.getcwd()
+            fn = os.getcwd()+'/' #this stops windows eating the current dir
         lines = text.split('\n')
         includes = {}
         for idx, l in enumerate(lines):

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -52,7 +52,7 @@ class Parser(object):
         # Per default use working directory of the process
         if fn is None:
             fn = os.getcwd()+'/'  
-            #this stops windows eating the current dir
+            # this stops windows eating the current dir
 
         lines = text.split('\n')
         includes = {}


### PR DESCRIPTION
When including a file inside a mapfile on a windows machine the current working directory is wrong as windows doesn't end it's paths with a '/' so [os.split](https://docs.python.org/2.7/library/os.path.html#os.path.split) treats the directory name as a file and removes it. 

This PR fixes the issue by adding a '/'. 