### PR TITLE
test and fix for issue #56

### DIFF
--- a/mappyfile/mapfile.lalr.g
+++ b/mappyfile/mapfile.lalr.g
@@ -116,7 +116,7 @@ INT: /[0-9]+(?![_a-zA-Z])/
 %import common.FLOAT
 
 // UNQUOTED_STRING: /[a-z_][a-z0-9_\-]*/i
-UNQUOTED_STRING: /[a-z0-9_\-]+/i
+UNQUOTED_STRING: /[a-z0-9_\-:]+/i
 DOUBLE_QUOTED_STRING: "\"" ("\\\""|/[^"]/)* "\"" "i"?
 SINGLE_QUOTED_STRING: "'" ("\\'"|/[^']/)* "'" "i"?
 ESCAPED_STRING: /`.*?`i?/

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -344,6 +344,16 @@ def test_list_expression_alt():
     assert(output(s) == exp)
 
 
+def test_class_expression_oddname():
+    s = '''
+    CLASS
+      TEXT ([area:ian])
+    END
+    '''
+    exp = "CLASS TEXT ([area:ian]) END"
+    assert(output(s) == exp)
+
+
 def run_tests():
     """
     Need to comment out the following line in C:\VirtualEnvs\mappyfile\Lib\site-packages\pep8.py


### PR DESCRIPTION
Allows expressions (and unquoted strings in general) to contain `:`.

Fixes  https://github.com/geographika/mappyfile/issues/56