### PR TITLE
fix for Issue #74 unicode problems with load()

### DIFF
--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -163,7 +163,9 @@ class Parser(object):
     def load(self, fp):
         text = fp.read()
         if os.path.isfile(fp.name):
-            fn = fp.name  # name is a read-only attribute and may not be present on all file-like objects.
+            # name is a read-only attribute and may not be present on
+            # all file-like objects.
+            fn = fp.name
         else:
             fn = None
         return self.parse(text, fn)
@@ -186,7 +188,11 @@ class Parser(object):
         Parse the Mapfile
         """
 
-        text = str(text)
+        if PY2 and not isinstance(text, unicode):
+            # specify Unicode for Python 2.7
+            text = unicode(text, 'UTF-8')
+        else:
+            text = str(text)
         if self.expand_includes:
             text = self.load_includes(text, fn=fn)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ jsonref==0.1
 glob2
 coveralls
 sphinx
+twisted

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,3 @@ jsonref==0.1
 glob2
 coveralls
 sphinx
-twisted

--- a/tests/samples/unicode.map
+++ b/tests/samples/unicode.map
@@ -1,0 +1,23 @@
+		CLASS
+
+			NAME 'Enw’r stryd ddynodedig'
+
+			EXPRESSION /^Designated street.*$/
+
+			STYLE
+
+				#SYMBOL 'line'
+
+				COLOR 255 0 0#red
+
+				OPACITY 100
+
+				OUTLINECOLOR 255 0 0
+
+				WIDTH 2
+
+			END
+
+			
+
+		END

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -114,6 +114,13 @@ def test_non_ascii():
     print(mappyfile.dumps(d))
 
 
+def test_unicode_map():
+    with open('./tests/samples/unicode.map', "r") as mf_file:
+        mf = mappyfile.load(mf_file)
+
+    print(mappyfile.dumps(mf))
+
+
 def run_tests():
     pytest.main(["tests/test_sample_maps.py"])
 


### PR DESCRIPTION
This checks if the object passed to parse() is a string or a unicode object (if you are using Python 2x) and if it is not a unicode object converts it to unicode.