### PR TITLE
fix: json schema for join tag

### DIFF
--- a/mappyfile/schemas/join.json
+++ b/mappyfile/schemas/join.json
@@ -45,6 +45,11 @@
       "type": "string",
       "enum": [ "one-to-one", "one-to-many" ],
       "additionalProperties": false
+    },
+    "connectiontype": {
+      "type": "string",
+      "enum": [ "csv", "mysql", "postgresql" ],
+      "additionalProperties": false
     }
   }
 }

--- a/mappyfile/schemas/layer.json
+++ b/mappyfile/schemas/layer.json
@@ -107,8 +107,11 @@
     "header": {
       "type": "string"
     },
-    "join": {
-      "type": "object"
+    "joins": {
+      "type": "array",
+      "items": {
+        "$ref": "join.json"
+      }
     },
     "labelangleitem": {
       "type": "string"


### PR DESCRIPTION
mappyfile: Version: 0.8.2

fix: schema layer.json for joins tag
fix: schema join.json for connectiontype tag

Note: The validate function does not manage the tag: joins and connectiontype, while the transform fonction (map to json) does it.

Reference: https://mapserver.org/mapfile/join.html

Error received on the validate function:
```
{'error': "'joins' does not match any of the regexes: '^__[a-z]+__$'", 'message': 'ERROR: Invalid value in LAYER'}
{'error': "'connectiontype' does not match any of the regexes: '^__[a-z]+__$'", 'message': 'ERROR: Invalid value in JOIN'}
```

MapFile abstract:
```
JOIN
	NAME 'table_join'
	CONNECTION "dbname=bd_test host=host_test port=5432 user=mapserver password={***}"
	CONNECTIONTYPE postgresql
	TABLE 'sch.table_join'
	FROM 'no_link'
	TO 'no_link'
	TYPE ONE-TO-MANY
	TEMPLATE "../gabarits/gabarit_join.html"
END
```

JSON-MapFile Abstract:
```
"joins": [
	{
		"__type__": "join",
		"name": "table_join",
		"connection": "dbname=bd_test host=host_test port=5432 user=mapserver password={***}",
		"connectiontype": "postgresql",
		"table": "sch.table_join",
		"from": "no_link",
		"to": "no_link",
		"type": "ONE-TO-MANY",
		"template": "../gabarits/gabarit_join.html"
	}
],
```