### PR TITLE
fix: add the object JOINS inside Hidden Container list

### DIFF
--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -278,7 +278,7 @@ class PrettyPrinter(object):
 
         if key in ("layers", "classes", "styles", "symbols", "labels",
                    "outputformats", "features", "scaletokens",
-                   "composites") and isinstance(val, list):
+                   "composites", "joins") and isinstance(val, list):
             return True
         else:
             return False


### PR DESCRIPTION
mappyfile: Version: 0.8.3

fix: add the object JOINS inside Hidden Container list

Issue: Bad mapfile format on bad conversion of object to mapfile output.
Resolution: The joins object tag must be managed as layers, outputformats, ....

relate at : 
- 90741fdae8c41633431ee6c3283e355258c2d7c3
- #87 

Bad output in mapfile:
```
JOINS "DefaultOrderedDict(<class 'mappyfile.ordereddict.CaseInsensitiveOrderedDict'>, CaseInsensitiveOrderedDict([('__type__', 'join'), ('__comments__', OrderedDict()), ('name', 'table_join'), ('connection', 'dbname=bd_test host=host_test port=5432 user=mapserver password={***}'), ('connectiontype', 'postgresql'), ('table', 'sch.table_join'), ('from', 'no_link'), ('to', 'no_link'), ('type', 'ONE-TO-MANY'), ('template', '../gabarits/gabarit_join.html')]))"
```

Sample mapFile origin:
```
JOIN
	NAME 'table_join'
	CONNECTION "dbname=bd_test host=host_test port=5432 user=mapserver password={***}"
	CONNECTIONTYPE postgresql
	TABLE 'sch.table_join'
	FROM 'no_link'
	TO 'no_link'
	TYPE ONE-TO-MANY
	TEMPLATE "../gabarits/gabarit_join.html"
END
```

Sample JSON-MapFile Abstract:
```
"joins": [
	{
		"__type__": "join",
		"name": "table_join",
		"connection": "dbname=bd_test host=host_test port=5432 user=mapserver password={***}",
		"connectiontype": "postgresql",
		"table": "sch.table_join",
		"from": "no_link",
		"to": "no_link",
		"type": "ONE-TO-MANY",
		"template": "../gabarits/gabarit_join.html"
	}
],
```
