### PR TITLE
Issue #89: fix for spaces in list attributes

### DIFF
--- a/mappyfile/mapfile.lalr.g
+++ b/mappyfile/mapfile.lalr.g
@@ -46,7 +46,7 @@ float_pair: float float
 path: PATH
 regexp: REGEXP1 | REGEXP2
 runtime_var: RUNTIME_VAR
-list: "{" (value | UNQUOTED_STRING) ("," (value | UNQUOTED_STRING))* "}"
+list: "{" (value | UNQUOTED_STRING_SPACE) ("," (value | UNQUOTED_STRING_SPACE))* "}"
 
 num_pair: (int|float) (int|float)
 
@@ -116,6 +116,7 @@ INT: /[0-9]+(?![_a-zA-Z])/
 
 // UNQUOTED_STRING: /[a-z_][a-z0-9_\-]*/i
 UNQUOTED_STRING: /[a-z0-9_\-:]+/i
+UNQUOTED_STRING_SPACE: /[a-z0-9_\-: ]+/i
 DOUBLE_QUOTED_STRING: "\"" ("\\\""|/[^"]/)* "\"" "i"?
 SINGLE_QUOTED_STRING: "'" ("\\'"|/[^']/)* "'" "i"?
 ESCAPED_STRING: /`.*?`i?/

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -356,6 +356,14 @@ def test_list_expression_alt():
     exp = "CLASS EXPRESSION {2_Klass,Rte2etr} END"
     assert(output(s) == exp)
 
+    s = """
+    CLASS
+        EXPRESSION {2_Klass,class with space}
+    END
+    """
+    exp = "CLASS EXPRESSION {2_Klass,class with space} END"
+    assert(output(s) == exp)
+
 
 def test_class_expression_oddname():
     s = '''


### PR DESCRIPTION
Allows the parser to recognise list expressions with spaces in the attribute names
