### PR TITLE
fix: print tag polaroffset and french unquoted string

### DIFF
--- a/mappyfile/mapfile.lalr.g
+++ b/mappyfile/mapfile.lalr.g
@@ -115,7 +115,8 @@ INT: /[0-9]+(?![_a-zA-Z])/
 %import common.FLOAT
 
 // UNQUOTED_STRING: /[a-z_][a-z0-9_\-]*/i
-UNQUOTED_STRING: /[a-z0-9_\-:]+/i
+// UNQUOTED_STRING: /[a-z0-9_\-:]+/i
+UNQUOTED_STRING: /[\w_\-:]+/i
 UNQUOTED_STRING_SPACE: /[a-z0-9_\-: ]+/i
 DOUBLE_QUOTED_STRING: "\"" ("\\\""|/[^"]/)* "\"" "i"?
 SINGLE_QUOTED_STRING: "'" ("\\'"|/[^']/)* "'" "i"?

--- a/mappyfile/mapfile.lalr.g
+++ b/mappyfile/mapfile.lalr.g
@@ -116,8 +116,9 @@ INT: /[0-9]+(?![_a-zA-Z])/
 
 // UNQUOTED_STRING: /[a-z_][a-z0-9_\-]*/i
 // UNQUOTED_STRING: /[a-z0-9_\-:]+/i
+// UNQUOTED_STRING_SPACE: /[a-z0-9_\-: ]+/i
 UNQUOTED_STRING: /[\w_\-:]+/i
-UNQUOTED_STRING_SPACE: /[a-z0-9_\-: ]+/i
+UNQUOTED_STRING_SPACE: /[\w_\-: ]+/i
 DOUBLE_QUOTED_STRING: "\"" ("\\\""|/[^"]/)* "\"" "i"?
 SINGLE_QUOTED_STRING: "'" ("\\'"|/[^']/)* "'" "i"?
 ESCAPED_STRING: /`.*?`i?/

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -390,7 +390,10 @@ class PrettyPrinter(object):
             new_values = []
 
             for v in value:
-                if not isinstance(v, numbers.Number):
+                if attr == "polaroffset":
+                    # don't add quotes to the fields list of polaroffset
+                    v = self.quoter.escape_quotes(v)
+                elif not isinstance(v, numbers.Number):
                     v = self.quoter.add_quotes(v)
                 new_values.append(v)
 


### PR DESCRIPTION
mappyfile: Version: 0.8.3
MapServer version 7.2.1

1. fix: output tag polaroffset

Issue: the output puts quotes on the list of fields on polaroffset
  ```
POLAROFFSET "[dist]" "[bearing_ms]"
  ```
Error received on validate mapfile:
```
UnexpectedToken(token, expected, state=state)
lark.exceptions.UnexpectedToken: Unexpected token Token(DOUBLE_QUOTED_STRING, '"[bearing_ms]"')
```
Resolution: don't add quotes to the fields list of polaroffset
```
POLAROFFSET [dist] [bearing_ms]
```
2.  fix: french characters not be permit on unquoted string

Issue: The french caracter are not interpreted as valid characters
```
EXPRESSION {Aérodrome,Aéroport,Héliport}
```
Error received:
```
UnexpectedCharacters(stream, line_ctr.char_pos, line_ctr.line, line_ctr.column, allowed=allowed, state=self.state, token_history=last_token and [last_token])
lark.exceptions.UnexpectedCharacters: No terminal defined for 'é'
```
Resolution: extend ASCII character list allowed with lars UNQUOTED_STRING. ex french character: éèàù
n.b: could be apply to another reg pattern