### PR TITLE
Add validation based on MapServer version

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -44,8 +44,8 @@ validate
 The ``validate`` command can be used to check values used in a Mapfile are valid, by comparing its contents to the Mapfile
 schema. It has the same parameters as the :ref:`validate <api-validate>` function. 
 
-The mappyfile development roadmap includes plans to allow validation against different versions of MapServer, for example validating Mapfiles 
-for MapServer 7.0, or for 7.2. It is unlikely versions before version 7.0 will be considered. 
+mappyfile also allow validation against different versions of MapServer, for example validating Mapfiles 
+for MapServer 7.0, or for 7.2. 
 
 .. note::
 
@@ -75,6 +75,15 @@ To validate a single Mapfile, without expanding any ``INCLUDE`` directives:
 .. code-block:: bat
 
     mappyfile validate /world.map --no-expand
+
+Example 3
++++++++++
+
+To validate a Mapfile for version 7.6 of MapServer:
+
+.. code-block:: bat
+
+    mappyfile validate /world.map --version=7.6
 
 To display the command's help text run the following: 
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -44,8 +44,8 @@ validate
 The ``validate`` command can be used to check values used in a Mapfile are valid, by comparing its contents to the Mapfile
 schema. It has the same parameters as the :ref:`validate <api-validate>` function. 
 
-mappyfile also allow validation against different versions of MapServer, for example validating Mapfiles 
-for MapServer 7.0, or for 7.2. 
+mappyfile also allows validation against different versions of MapServer, for example validating Mapfiles 
+for MapServer 7.0, or for 7.6. 
 
 .. note::
 

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -83,7 +83,7 @@ Mapfile validation can either be run using the :ref:`cli`, or directly in Python
 
     d = mappyfile.loads(s, include_position=True)
     v = Validator()
-    errors = v.validate(d, add_comments=True)
+    errors = v.validate(d, add_comments=True, version=7.6)
     for e in errors:
         print(e)
 
@@ -95,6 +95,32 @@ Outputs the following:
 
 The ``include_position`` parameter can be set to ``True`` when loading a Mapfile (or Mapfile snippet), so that any validation errors
 include line positions. 
+
+The optional ``version`` parameter can be used to validate the Mapfile against a specific 
+version of MapServer. 
+
+..
+    If a ``$ref`` is used then all other properties are ignored. 
+
+        You will always use $ref as the only key in an object: any other keys you put 
+        there will be ignored by the validator.
+
+    See https://json-schema.org/understanding-json-schema/structuring.html#reuse
+
+    .. code-block:: json
+
+        "color": {
+          "allOf": [
+            {
+              "$ref": "color.json"
+            }
+          ],
+          "metadata": {
+            "deprecated": true,
+            "maxVersion": 7.6
+          }
+        },
+
 
 ..
     Some keywords when missing will raise errors when trying to generate a map, for example if a ``MAP`` has no ``SIZE``:

--- a/mappyfile/schemas/class.json
+++ b/mappyfile/schemas/class.json
@@ -18,7 +18,15 @@
       "$ref": "color.json"
     },
     "color": {
-      "$ref": "color.json"
+      "allOf": [
+        {
+          "$ref": "color.json"
+        }
+      ],
+      "metadata": {
+        "deprecated": true,
+        "maxVersion": 7.6
+      }
     },
     "debug": {
       "$ref": "onoff.json"

--- a/mappyfile/schemas/label.json
+++ b/mappyfile/schemas/label.json
@@ -86,7 +86,17 @@
       ]
     },
     "force": {
-      "type": "boolean"
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "enum": [ "group" ],
+          "metadata": {
+            "minVersion": 6.2
+          }
+        }
+      ]
     },
     "maxlength": {
       "type": "integer"

--- a/mappyfile/schemas/label.json
+++ b/mappyfile/schemas/label.json
@@ -15,9 +15,21 @@
       }
     },
     "align": {
-      "type": "string",
-      "enum": [ "left", "center", "right" ],
-      "additionalProperties": false
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [ "left", "center", "right" ],
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "pattern": "^\\[(.*?)\\]$",
+          "description": "attribute"
+        }
+      ],
+      "metadata": {
+        "minVersion": 5.4
+      }
     },
     "angle": {
       "oneOf": [
@@ -106,12 +118,26 @@
       "type": "integer"
     },
     "offset": {
-      "type": "array",
-      "items": {
-        "type": "number"
-      },
-      "minItems": 2,
-      "maxItems": 2
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^\\[(.*?)\\]$",
+            "description": "attribute"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
     },
     "outlinecolor": {
       "oneOf": [
@@ -184,7 +210,7 @@
       ]
     },
     "size": {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "integer"
         },
@@ -197,6 +223,9 @@
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute"
+        },
+        {
+          "$ref": "expression.json"
         }
       ]
     },

--- a/mappyfile/schemas/symbol.json
+++ b/mappyfile/schemas/symbol.json
@@ -33,9 +33,18 @@
       "$ref": "color.json"
     },
     "character": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 1
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1
+        },
+        {
+          "pattern": "^&#[0-9]+;$",
+          "example": "&#10140;",
+          "type": "string"
+        }
+      ]
     },
     "filled": {
       "type": "boolean"

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -590,15 +590,19 @@ def update(d1, d2):
     return d1
 
 
-def validate(d):
+def validate(d, version=None):
     """
-    Validate a mappyfile dictionary by using the Mapfile schema
+    Validate a mappyfile dictionary by using the Mapfile schema.
+    An optional version number can be used to specify a specific
+    a Mapfile is valid for a specific MapServer version.
 
     Parameters
     ----------
 
     d: dict
         A Python dictionary based on the the mappyfile schema
+   version: float
+        The MapServer version number used to validate the Mapfile
 
     Returns
     -------
@@ -608,7 +612,7 @@ def validate(d):
 
     """
     v = Validator()
-    return v.validate(d)
+    return v.validate(d, version=version)
 
 
 def _save(output_file, map_string):

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -108,14 +108,14 @@ class Validator(object):
         for key in keys_copy:
             v = properties[key]
             if isinstance(v, dict):
-                if self.is_valid_for_version(v, version) == False:
+                if self.is_valid_for_version(v, version) is False:
                     del properties[key]
                 self.get_versioned_schema(v, version)
             elif isinstance(v, list):
                 valid_list = []
                 for props in v:
                     if isinstance(props, dict):
-                        if self.is_valid_for_version(props, version) != False:
+                        if self.is_valid_for_version(props, version) is True:
                             valid_list.append(props)
                     else:
                         valid_list.append(props)

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -31,7 +31,6 @@ import json
 import os
 import sys
 from collections import OrderedDict
-import math
 import logging
 import jsonschema
 import jsonref
@@ -89,7 +88,7 @@ class Validator(object):
             if "metadata" in v:
                 md = v["metadata"]
                 min_version = md.get("minVersion", 0.0)
-                max_version = md.get("maxVersion", math.inf)
+                max_version = md.get("maxVersion", 1000.0)
                 if version < min_version or version > max_version:
                     del properties[k]
 
@@ -225,7 +224,7 @@ class Validator(object):
             jsn_schema["properties"] = self.get_versioned_schema(properties, version)
             validator = jsonschema.Draft4Validator(schema=jsn_schema)
         else:
-            validator = self.get_schema_validator(schema_name, version)
+            validator = self.get_schema_validator(schema_name)
 
         error_messages = []
 

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -181,7 +181,7 @@ class Validator(object):
         # include position details
 
         if "__position__" in d:
-            if not path:
+            if not path or key not in d["__position__"]:
                 # position for the root object is stored in the root of the dict
                 pd = d["__position__"]
             else:

--- a/tests/mapfiles/profiler.py
+++ b/tests/mapfiles/profiler.py
@@ -11,21 +11,39 @@ def parse(mf):
     return s
 
 
-def profile(mf, test_name):
+def log_profile_output(pr, output_file):
+
+    sortby = 'tottime'
     sortby = 'time'
+
+    with open(output_file, "w") as f:
+        ps = pstats.Stats(pr, stream=f).sort_stats(sortby)
+        ps.print_stats()
+
+    # pr.dump_stats(fn)
+    # pr.print_stats(sort='time')
+
+
+def profile(mf, test_name):
 
     pr = cProfile.Profile()
     pr.enable()
     parse(mf)
     pr.disable()
+    output_file = os.path.join(os.path.dirname(__file__), "performance", test_name, "{}.txt".format(os.path.basename(mf)))
+    log_profile_output(pr, output_file)
 
-    fn = os.path.join(os.path.dirname(__file__), "performance", test_name, "{}.txt".format(os.path.basename(mf)))
 
-    with open(fn, "w") as f:
-        ps = pstats.Stats(pr, stream=f).sort_stats(sortby)
-        ps.print_stats()
-    # pr.dump_stats(fn)
-    # pr.print_stats(sort='time')
+def profile_test():
+    from tests.test_validation import test_version_warnings
+    test_name = "test_version_warnings"
+    pr = cProfile.Profile()
+    pr.enable()
+    test_version_warnings()
+    pr.disable()
+    output_file = os.path.join(os.path.dirname(__file__), "performance", "{}.txt".format(test_name))
+    print(output_file)
+    log_profile_output(pr, output_file)
 
 
 def run(test_name):
@@ -41,5 +59,6 @@ def run(test_name):
 
 if __name__ == "__main__":
     test_name = "run3-py27"
-    run(test_name)
+    # run(test_name)
+    profile_test()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -530,7 +530,7 @@ END"""
     v = Validator()
     errors = v.validate(d, add_comments=True, version=8.0)
     print(errors)
-    print(json.dumps(d, indent=4))
+    assert len(errors) == 1
 
 
 def run_tests():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -533,6 +533,63 @@ END"""
     assert len(errors) == 1
 
 
+def test_keyword_versioning():
+
+    properties = {
+  "type": "object",
+  "properties": {
+    "__type__": {
+      "enum": [ "label" ]
+    },
+    "align": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [ "left", "center", "right" ],
+          "additionalProperties": False
+        },
+        {
+          "type": "string",
+          "pattern": "^\\[(.*?)\\]$",
+          "description": "attribute"
+        }
+      ],
+      "metadata": {
+        "minVersion": 5.4
+      }
+    }
+  }
+}
+
+    v = Validator()
+    assert "align" in properties["properties"].keys()
+    properties = v.get_versioned_schema(properties, 5.2)
+    print(json.dumps(properties, indent=4))
+    assert "align" not in properties["properties"].keys()
+
+def test_property_versioning():
+
+    properties = {
+      "force": {
+      "oneOf": [
+        {"type": "boolean"},
+        {
+          "enum": [ "group" ],
+          "metadata": {
+            "minVersion": 6.2
+          }
+        }]
+      }
+    }
+
+    v = Validator()
+    assert "enum" in properties["force"]["oneOf"][1].keys()
+    assert len(properties["force"]["oneOf"]) == 2
+    properties = v.get_versioned_schema(properties, 6.0)
+    print(json.dumps(properties, indent=4))
+    assert len(properties["force"]["oneOf"]) == 1
+
+
 def run_tests():
     pytest.main(["tests/test_validation.py"])
 
@@ -540,6 +597,7 @@ def run_tests():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
-    test_cluster_validation_fail()
+    test_property_versioning()
     test_version_warnings()
+    test_keyword_versioning()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -512,6 +512,27 @@ def test_cluster_validation_fail():
     assert len(errors) == 1
 
 
+def test_version_warnings():
+
+    s = """MAP
+    NAME "sample"
+    LAYER
+        NAME "test"
+        TYPE LINE
+        CLASS
+            #MADEUP True
+            COLOR 0 0 0
+        END
+    END
+END"""
+
+    d = mappyfile.loads(s, include_position=False)
+    v = Validator()
+    errors = v.validate(d, add_comments=True, version=8.0)
+    print(errors)
+    print(json.dumps(d, indent=4))
+
+
 def run_tests():
     pytest.main(["tests/test_validation.py"])
 
@@ -520,4 +541,5 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
     test_cluster_validation_fail()
+    test_version_warnings()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -539,13 +539,13 @@ def test_keyword_versioning():
   "type": "object",
   "properties": {
     "__type__": {
-      "enum": [ "label" ]
+      "enum": ["label"]
     },
     "align": {
       "oneOf": [
         {
           "type": "string",
-          "enum": [ "left", "center", "right" ],
+          "enum": ["left", "center", "right"],
           "additionalProperties": False
         },
         {
@@ -567,6 +567,7 @@ def test_keyword_versioning():
     print(json.dumps(properties, indent=4))
     assert "align" not in properties["properties"].keys()
 
+
 def test_property_versioning():
 
     properties = {
@@ -574,7 +575,7 @@ def test_property_versioning():
       "oneOf": [
         {"type": "boolean"},
         {
-          "enum": [ "group" ],
+          "enum": ["group"],
           "metadata": {
             "minVersion": 6.2
           }


### PR DESCRIPTION
Allow validation against different versions of MapServer, for example validating Mapfiles for MapServer 7.0, or for 7.2. 
A new version parameter can be passed to the Validator class or used on the command line. 


