### PR TITLE
Add example and parsing for mixed attribute pairs

### DIFF
--- a/mappyfile/mapfile.lalr.g
+++ b/mappyfile/mapfile.lalr.g
@@ -55,7 +55,7 @@ attr: (UNQUOTED_STRING | composite_type) (value | UNQUOTED_STRING)
 
 ?value: string | int | float | expression | not_expression | attr_bind | path
 | regexp | runtime_var | list | NULL | true | false | extent | rgb | hexcolor
-| colorrange | hexcolorrange | num_pair | attr_bind_pair | _attr_keyword
+| colorrange | hexcolorrange | num_pair | attr_bind_pair | attr_mixed_pair | _attr_keyword
 
 int: SIGNED_INT
 int_pair: int int
@@ -72,6 +72,7 @@ string: DOUBLE_QUOTED_STRING | SINGLE_QUOTED_STRING | ESCAPED_STRING
 string_pair: (string|UNQUOTED_STRING) (string|UNQUOTED_STRING)
 
 attr_bind_pair: attr_bind attr_bind
+attr_mixed_pair: attr_bind (int|float) | (int|float) attr_bind
 float: SIGNED_FLOAT
 float_pair: float float
 path: PATH

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -412,8 +412,8 @@ class PrettyPrinter(object):
             new_values = []
 
             for v in value:
-                if not isinstance(v, numbers.Number) and attr != "polaroffset":
-                    # don't add quotes to list of attributes for polaroffset
+                if not isinstance(v, numbers.Number) and attr not in ["offset", "polaroffset"]:
+                    # don't add quotes to list of attributes for offset / polaroffset
                     v = self.quoter.add_quotes(v)
                 new_values.append(v)
 

--- a/mappyfile/transformer.py
+++ b/mappyfile/transformer.py
@@ -599,6 +599,10 @@ class MapfileTransformer(Transformer, object):
         assert len(t) == 2
         return t
 
+    def attr_mixed_pair(self, t):
+        assert len(t) == 2
+        return t
+
     def colorrange(self, t):
         assert len(t) == 6
         return t

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -164,6 +164,33 @@ def test_style_pattern5():
     assert(output(s, schema_name="style") == exp)
 
 
+def test_style_offset_mixed():
+    """
+    Test an attribute and numerical pair for a STYLE OFFSET
+    See https://github.com/geographika/mappyfile/issues/114
+    """
+    s = """
+    STYLE
+        OFFSET [attribute] -999
+    END
+    """
+    exp = "STYLE OFFSET [attribute] -999 END"
+    assert(output(s, schema_name="style") == exp)
+
+
+def test_style_offset_mixed2():
+    """
+    As above but reversed
+    """
+    s = """
+    STYLE
+        OFFSET -999 [attribute]
+    END
+    """
+    exp = "STYLE OFFSET -999 [attribute] END"
+    assert(output(s, schema_name="style") == exp)
+
+
 def test_metadata():
     """
     Parse metadata directly
@@ -958,6 +985,6 @@ def run_tests():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    test_font_symbol()
+    test_style_offset_mixed2()
     # run_tests()
     print("Done!")


### PR DESCRIPTION
`OFFSET` and `POLAROFFSET` allow the following attribute pairs `[double|attribute] [double|attribute]` - combinations of bound attributes and values. This pull request allows these to be parsed correctly. See #114. 