### PR TITLE
proposal to trace the includes files

### DIFF
--- a/mappyfile/cli.py
+++ b/mappyfile/cli.py
@@ -36,6 +36,7 @@ import logging
 import click
 import mappyfile
 from mappyfile.validator import Validator
+from sys import argv
 
 
 def get_mapfiles(mapfiles):
@@ -57,7 +58,11 @@ def configure_logging(verbosity):
     None
     """
     log_level = max(10, 30 - 10 * verbosity)
-    logging.basicConfig(stream=sys.stderr, level=log_level)
+    # use stdout for output librairie Warning (ex: ... >> output.txt)
+    if log_level < 40:
+        logging.basicConfig(stream=sys.stdout, level=log_level)
+    else:
+        logging.basicConfig(stream=sys.stderr, level=log_level)
 
 
 logger = logging.getLogger(__name__)
@@ -111,7 +116,7 @@ def format(ctx, input_mapfile, output_mapfile, indent, spacer, quote, newlinecha
     spacer = codecs.decode(spacer, 'unicode_escape')  # ensure \t is handled as a tab
     newlinechar = codecs.decode(newlinechar, 'unicode_escape')  # ensure \n is handled as a newline
 
-    d = mappyfile.open(input_mapfile, expand_includes=expand, include_comments=comments, include_position=True)
+    d, trace_o_incl = mappyfile.open(input_mapfile, expand_includes=expand, include_comments=comments, include_position=True)
     mappyfile.save(d, output_mapfile, indent=indent, spacer=spacer, quote=quote, newlinechar=newlinechar)
     sys.exit(0)
 
@@ -151,17 +156,17 @@ def validate(ctx, mapfiles, expand, version):
     for fn in all_mapfiles:
         fn = click.format_filename(fn)
         try:
-            d = mappyfile.open(fn, expand_includes=expand, include_position=True)
+            d, trace_o_incl = mappyfile.open(fn, expand_includes=expand, include_position=True)
         except Exception as ex:
             logger.exception(ex)
             click.echo("{} failed to parse successfully".format(fn))
             continue
 
-        validation_messages = mappyfile.validate(d, version)
+        validation_messages = mappyfile.validate(d, trace_o_incl, version)
         if validation_messages:
             for v in validation_messages:
                 v["fn"] = fn
-                msg = "{fn} (Line: {line} Column: {column}) {message} - {error}".format(**v)
+                msg = "{fn} (File: {file} Line: {line} Column: {column}) {message} - {error}".format(**v)
                 click.echo(msg)
                 errors += 1
         else:
@@ -171,6 +176,11 @@ def validate(ctx, mapfiles, expand, version):
     click.echo("{} file(s) validated ({} successfully)".format(len(all_mapfiles), validation_count))
     sys.exit(errors)
 
+if __name__ == '__main__':
+    if getattr(sys, 'frozen', False):
+        main(argv[1:])
+    else:
+        main()
 
 @main.command(short_help="Export a Mapfile Schema")
 @click.argument('output_file', nargs=1, type=click.Path())

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -60,7 +60,7 @@ def deprecated(func):
     return new_func
 
 
-def open(fn, expand_includes=True, include_comments=False, include_position=False, **kwargs):
+def open(fn, output_o_trace=False, expand_includes=True, include_comments=False, include_position=False, **kwargs):
     """
     Load a Mapfile from the supplied filename into a Python dictionary.
 
@@ -69,6 +69,8 @@ def open(fn, expand_includes=True, include_comments=False, include_position=Fals
 
     fn: string
         The path to the Mapfile, or partial Mapfile
+    output_o_trace: boolean
+        To include a trace of origin include files in the output: tuple (dict, list)
     expand_includes: boolean
         Load any ``INCLUDE`` files in the MapFile
     include_comments: boolean
@@ -81,6 +83,9 @@ def open(fn, expand_includes=True, include_comments=False, include_position=Fals
 
     dict
         A Python dictionary representing the Mapfile in the mappyfile format
+
+    trace_o_incl*
+        A trace of the origin of lines for include files, use to find the original location of an error
 
     Example
     -------
@@ -97,11 +102,17 @@ def open(fn, expand_includes=True, include_comments=False, include_position=Fals
     """
     p = Parser(expand_includes=expand_includes,
                include_comments=include_comments, **kwargs)
-    ast = p.parse_file(fn)
+    ast, trace_o_incl = p.parse_file(fn)
     m = MapfileToDict(include_position=include_position,
-                      include_comments=include_comments, **kwargs)
+                      include_comments=include_comments,
+                      trace_o_incl=trace_o_incl,
+                       **kwargs)
+                       
     d = m.transform(ast)
-    return d
+    if output_o_trace == True:
+        return d, trace_o_incl
+    else:
+        return d
 
 
 def load(fp, expand_includes=True, include_position=False, include_comments=False, **kwargs):
@@ -590,7 +601,7 @@ def update(d1, d2):
     return d1
 
 
-def validate(d, version=None):
+def validate(d, *trace_o_incl, version=None):
     """
     Validate a mappyfile dictionary by using the Mapfile schema.
     An optional version number can be used to specify a specific
@@ -601,7 +612,9 @@ def validate(d, version=None):
 
     d: dict
         A Python dictionary based on the the mappyfile schema
-   version: float
+    trace_o_incl: list (optional)
+        A trace of the origin of lines for include files, use to find the original location of an error
+    version: float
         The MapServer version number used to validate the Mapfile
 
     Returns
@@ -612,7 +625,9 @@ def validate(d, version=None):
 
     """
     v = Validator()
-    return v.validate(d, version=version)
+    if not trace_o_incl:
+        trace_o_incl = None
+    return v.validate(d, trace_o_incl, version=version)
 
 
 def _save(output_file, string):


### PR DESCRIPTION
A proposal to track files included in error messages or during common use.
The detour to get there is not ideal but it meets the need to know the position of a line in the original file.

Sample use: 
- for validate a file:
```
mapService, traceFile = mappyfile.open(strPathMapFile, output_trace=True, include_position=True) 
errors = mappyfile.validate(mapService, traceFile, version=7.6)
for e in errors:
    print(e)
```

- for commun use:
```
mapService, traceFile = mappyfile.open(strPathMapFile, output_trace=True, include_position=True)
for lay in layers:
    # trace original include mapFile of Layer
    pd = lay["__position__"]
    trace = traceFile[pd.get("line")]
    originFile = traceFile[0][trace]
```