### PR TITLE
Add default values to schema and a new create function

### DIFF
--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -18,6 +18,7 @@ These are functions used to open and write Mapfiles to files and strings.
 + :func:`mappyfile.dump`
 + :func:`mappyfile.dumps`
 + :func:`mappyfile.save`
++ :func:`mappyfile.create`
 
 .. automodule:: mappyfile
 
@@ -38,6 +39,10 @@ These are functions used to open and write Mapfiles to files and strings.
 .. _api-save:
 
     .. autofunction:: save
+
+.. _api-create:
+
+    .. autofunction:: create
 
 
 Dictionary Helper Functions

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -22,7 +22,7 @@ Run from the root of the mappyfile project folder:
 
     set MAPPYFILE_PATH=D:\GitHub\mappyfile
     set VIRTUALENV=C:\VirtualEnvs\mappyfile3
-    cd /D "C:\Python37\Scripts"
+    cd /D "C:\Python310\Scripts"
     REM cd /D "C:\Python27\Scripts"
     pip install virtualenv
     virtualenv %VIRTUALENV%

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -73,6 +73,7 @@ Linting
 
     flake8 --ignore=E501,E121,E122,E123,E126,E127,E128 tests --exclude=*/basemaps/*,*/ms-ogc-workshop/*
     flake8 mappyfile --max-line-length=120
+    flake8 docs/scripts --max-line-length=120
 
 Or to export to file:
 

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -13,6 +13,14 @@ PSC (Project Steering Committee). Further details on the schema are outlined in 
 Exporting the Schema
 ++++++++++++++++++++
 
+The schema can be exported via the command-line using the following syntax:
+
+.. code-block:: bat
+
+    mappyfile schema mapfile-schema-7-6.json --version=7.6
+
+The schema can be exported using Python, as shown in the example below:
+
 .. code-block:: python
 
     import json

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -4,11 +4,36 @@ Mapfile Schema
 ==============
 
 The full Mapfile schema is shown below. It can also be downloaded directly from this link - :download:`mapfile.json <schemas/mapfile.json>`. 
-The current schema is valid for the most recent release of MapServer (7.2). There are plans on the development roadmap to create schemas for
-different versions of MapServer, so Mapfiles can be validated against older or newer releases of MapServer to see if they are still valid. 
+The schema stores ``minVersion`` and ``maxVersion`` properties in a ``metadata`` object for each keyword. This allow Mapfiles to be validated against
+older or newer releases of MapServer to see if they are still valid. 
 
 The Mapfile schema shown below is planned to be proposed as an official Mapfile language schema, subject to voting by the MapServer
 PSC (Project Steering Committee). Further details on the schema are outlined in the draft RFC (Request for Comment) at :ref:`rfc123`. 
+
+Exporting the Schema
+++++++++++++++++++++
+
+.. code-block:: python
+
+    import json
+    from mappyfile.validator import Validator
+
+    validator = Validator()
+    jsn = validator.get_versioned_schema(version=8.0)
+    print(json.dumps(jsn, indent=4))
+
+Creating a Mappyfile Object with Defaults
++++++++++++++++++++++++++++++++++++++++++
+
+.. code-block:: python
+
+    import json
+    import mappyfile
+
+    m = mappyfile.create("map", version=8.0)
+    print(json.dumps(m, indent=4, sort_keys=True))
+    mappyfile.dumps(m)
+
 
 .. literalinclude:: schemas/mapfile.json
     :language: json

--- a/docs/schemas/mapfile.json
+++ b/docs/schemas/mapfile.json
@@ -23,10 +23,114 @@
             ]
         }, 
         "reference": {
-            "type": "object"
+            "additionalProperties": false, 
+            "type": "object", 
+            "patternProperties": {
+                "^__[a-z]+__$": {}
+            }, 
+            "properties": {
+                "status": {
+                    "enum": [
+                        "on", 
+                        "off"
+                    ], 
+                    "type": "string"
+                }, 
+                "color": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "image": {
+                    "type": "string", 
+                    "description": "filename"
+                }, 
+                "markersize": {
+                    "type": "integer"
+                }, 
+                "__type__": {
+                    "enum": [
+                        "reference"
+                    ]
+                }, 
+                "outlinecolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "maxboxsize": {
+                    "type": "integer"
+                }, 
+                "extent": {
+                    "minItems": 4, 
+                    "items": {
+                        "type": "number"
+                    }, 
+                    "type": "array", 
+                    "maxItems": 4
+                }, 
+                "marker": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }, 
+                "include": {
+                    "items": {
+                        "type": "string"
+                    }, 
+                    "type": "array"
+                }, 
+                "minboxsize": {
+                    "type": "integer"
+                }, 
+                "size": {
+                    "minItems": 2, 
+                    "items": {
+                        "type": "integer"
+                    }, 
+                    "type": "array", 
+                    "maxItems": 2
+                }
+            }
         }, 
         "defresolution": {
-            "type": "integer"
+            "type": "number", 
+            "metadata": {
+                "minVersion": 5.6
+            }
         }, 
         "symbols": {
             "items": {
@@ -52,7 +156,10 @@
                             }
                         ], 
                         "type": "array", 
-                        "maxItems": 2
+                        "maxItems": 2, 
+                        "metadata": {
+                            "minVersion": 6.2
+                        }
                     }, 
                     "name": {
                         "type": "string"
@@ -66,12 +173,24 @@
                         "type": "string"
                     }, 
                     "character": {
-                        "minLength": 1, 
-                        "type": "string", 
-                        "maxLength": 1
+                        "oneOf": [
+                            {
+                                "minLength": 1, 
+                                "type": "string", 
+                                "maxLength": 1
+                            }, 
+                            {
+                                "pattern": "^&#[0-9]+;$", 
+                                "type": "string", 
+                                "example": "&#10140;"
+                            }
+                        ]
                     }, 
                     "antialias": {
-                        "type": "boolean"
+                        "type": "boolean", 
+                        "metadata": {
+                            "maxVersion": 7.6
+                        }
                     }, 
                     "points": {
                         "items": {
@@ -97,7 +216,7 @@
                                 "maxItems": 3
                             }, 
                             {
-                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                 "type": "string", 
                                 "example": "#aa33cc"
                             }
@@ -117,7 +236,10 @@
                         ]
                     }, 
                     "transparent": {
-                        "type": "integer"
+                        "type": "integer", 
+                        "metadata": {
+                            "maxVersion": 7.6
+                        }
                     }, 
                     "filled": {
                         "type": "boolean"
@@ -128,32 +250,108 @@
         }, 
         "outputformats": {
             "items": {
-                "type": "object"
+                "additionalProperties": false, 
+                "type": "object", 
+                "patternProperties": {
+                    "^__[a-z]+__$": {}
+                }, 
+                "properties": {
+                    "mimetype": {
+                        "type": "string"
+                    }, 
+                    "__comments__": {
+                        "type": "object"
+                    }, 
+                    "extension": {
+                        "type": "string"
+                    }, 
+                    "__type__": {
+                        "enum": [
+                            "outputformat"
+                        ]
+                    }, 
+                    "__position__": {
+                        "type": "object"
+                    }, 
+                    "driver": {
+                        "type": "string"
+                    }, 
+                    "formatoption": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "imagemode": {
+                        "additionalProperties": false, 
+                        "enum": [
+                            "pc256", 
+                            "rgb", 
+                            "rgba", 
+                            "byte", 
+                            "int16", 
+                            "float32", 
+                            "feature"
+                        ], 
+                        "type": "string"
+                    }, 
+                    "include": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "transparent": {
+                        "enum": [
+                            "on", 
+                            "off"
+                        ], 
+                        "type": "string"
+                    }, 
+                    "name": {
+                        "type": "string"
+                    }
+                }
             }, 
             "type": "array"
         }, 
         "transparent": {
-            "enum": [
-                "on", 
-                "off"
+            "allOf": [
+                {
+                    "enum": [
+                        "on", 
+                        "off"
+                    ], 
+                    "type": "string"
+                }
             ], 
-            "type": "string"
+            "metadata": {
+                "maxVersion": 7.6
+            }
         }, 
         "imagetype": {
+            "default": "png", 
             "type": "string"
         }, 
         "size": {
-            "minItems": 2, 
+            "default": [
+                -1, 
+                -1
+            ], 
             "items": {
                 "type": "integer"
             }, 
             "type": "array", 
+            "minItems": 2, 
             "maxItems": 2
         }, 
         "layers": {
             "items": {
                 "additionalProperties": false, 
                 "type": "object", 
+                "required": [
+                    "type"
+                ], 
                 "patternProperties": {
                     "^__[a-z]+__$": {}
                 }, 
@@ -174,7 +372,10 @@
                         "type": "string"
                     }, 
                     "opacity": {
-                        "type": "integer"
+                        "type": "integer", 
+                        "metadata": {
+                            "maxVersion": 7.6
+                        }
                     }, 
                     "features": {
                         "items": {
@@ -241,18 +442,23 @@
                         "type": "string"
                     }, 
                     "encoding": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "minVersion": 7.0
+                        }
                     }, 
                     "maxfeatures": {
                         "type": "integer"
                     }, 
                     "maxscaledenom": {
-                        "type": "number"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.0
+                        }
                     }, 
                     "maxscale": {
                         "type": "number", 
                         "metadata": {
-                            "deprecated": true, 
                             "maxVersion": 5.0
                         }
                     }, 
@@ -260,6 +466,7 @@
                         "enum": [
                             "contour", 
                             "kerneldensity", 
+                            "idw", 
                             "local", 
                             "ogr", 
                             "oraclespatial", 
@@ -276,16 +483,160 @@
                     "labelminscale": {
                         "type": "number", 
                         "metadata": {
-                            "deprecated": true, 
-                            "minVersion": 0, 
                             "maxVersion": 5.0
                         }
                     }, 
                     "cluster": {
-                        "type": "object"
+                        "allOf": [
+                            {
+                                "additionalProperties": false, 
+                                "type": "object", 
+                                "patternProperties": {
+                                    "^__[a-z]+__$": {}
+                                }, 
+                                "properties": {
+                                    "group": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }, 
+                                    "buffer": {
+                                        "type": "number"
+                                    }, 
+                                    "region": {
+                                        "oneOf": [
+                                            {
+                                                "pattern": "^rectangle$", 
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^ellipse$", 
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }, 
+                                    "__type__": {
+                                        "enum": [
+                                            "cluster"
+                                        ]
+                                    }, 
+                                    "filter": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }, 
+                                    "include": {
+                                        "items": {
+                                            "type": "string"
+                                        }, 
+                                        "type": "array"
+                                    }, 
+                                    "maxdistance": {
+                                        "type": "number"
+                                    }
+                                }
+                            }
+                        ], 
+                        "metadata": {
+                            "minVersion": 6.0
+                        }
+                    }, 
+                    "joins": {
+                        "items": {
+                            "additionalProperties": false, 
+                            "type": "object", 
+                            "patternProperties": {
+                                "^__[a-z]+__$": {}
+                            }, 
+                            "properties": {
+                                "from": {
+                                    "type": "string"
+                                }, 
+                                "name": {
+                                    "type": "string"
+                                }, 
+                                "footer": {
+                                    "type": "string", 
+                                    "description": "filename"
+                                }, 
+                                "__type__": {
+                                    "enum": [
+                                        "join"
+                                    ]
+                                }, 
+                                "connectiontype": {
+                                    "additionalProperties": false, 
+                                    "enum": [
+                                        "csv", 
+                                        "mysql", 
+                                        "postgresql"
+                                    ], 
+                                    "type": "string"
+                                }, 
+                                "header": {
+                                    "type": "string", 
+                                    "description": "filename"
+                                }, 
+                                "connection": {
+                                    "type": "string"
+                                }, 
+                                "template": {
+                                    "type": "string", 
+                                    "description": "filename"
+                                }, 
+                                "table": {
+                                    "type": "string"
+                                }, 
+                                "include": {
+                                    "items": {
+                                        "type": "string"
+                                    }, 
+                                    "type": "array"
+                                }, 
+                                "type": {
+                                    "additionalProperties": false, 
+                                    "enum": [
+                                        "one-to-one", 
+                                        "one-to-many"
+                                    ], 
+                                    "type": "string"
+                                }, 
+                                "to": {
+                                    "type": "string"
+                                }
+                            }
+                        }, 
+                        "type": "array"
                     }, 
                     "minscaledenom": {
-                        "type": "number"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.0
+                        }
                     }, 
                     "projection": {
                         "oneOf": [
@@ -309,8 +660,6 @@
                     "labelmaxscale": {
                         "type": "number", 
                         "metadata": {
-                            "deprecated": true, 
-                            "minVersion": 0, 
                             "maxVersion": 5.0
                         }
                     }, 
@@ -329,7 +678,10 @@
                                 ], 
                                 "type": "string"
                             }
-                        ]
+                        ], 
+                        "metadata": {
+                            "maxVersion": 7.6
+                        }
                     }, 
                     "footer": {
                         "type": "string"
@@ -338,7 +690,10 @@
                         "type": "string"
                     }, 
                     "mingeowidth": {
-                        "type": "number"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.4
+                        }
                     }, 
                     "labelrequires": {
                         "type": "string"
@@ -376,7 +731,10 @@
                         "type": "string"
                     }, 
                     "labelangleitem": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "maxVersion": 5.6
+                        }
                     }, 
                     "metadata": {
                         "additionalProperties": true, 
@@ -390,6 +748,7 @@
                         "type": "string"
                     }, 
                     "units": {
+                        "default": "meters", 
                         "enum": [
                             "dd", 
                             "feet", 
@@ -411,7 +770,10 @@
                                 "pattern": "^\\((.*?)\\)$", 
                                 "type": "string"
                             }
-                        ]
+                        ], 
+                        "metadata": {
+                            "minVersion": 6.4
+                        }
                     }, 
                     "include": {
                         "items": {
@@ -432,9 +794,13 @@
                         ]
                     }, 
                     "labelmaxscaledenom": {
-                        "type": "number"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.0
+                        }
                     }, 
                     "status": {
+                        "default": "off", 
                         "enum": [
                             "on", 
                             "off", 
@@ -443,7 +809,10 @@
                         "type": "string"
                     }, 
                     "utfdata": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "minVersion": 7.0
+                        }
                     }, 
                     "processing": {
                         "items": {
@@ -489,10 +858,25 @@
                                 }
                             }
                         }, 
-                        "type": "array"
+                        "type": "array", 
+                        "metadata": {
+                            "minVersion": 6.4
+                        }
                     }, 
-                    "plugin": {
-                        "type": "string"
+                    "connectionoptions": {
+                        "allOf": [
+                            {
+                                "additionalProperties": true, 
+                                "type": "object", 
+                                "properties": {}, 
+                                "metadata": {
+                                    "minVersion": 7.6
+                                }
+                            }
+                        ], 
+                        "metadata": {
+                            "minVersion": 7.6
+                        }
                     }, 
                     "grid": {
                         "additionalProperties": false, 
@@ -552,30 +936,38 @@
                         "maxItems": 4
                     }, 
                     "tileitem": {
+                        "default": "location", 
                         "type": "string"
                     }, 
                     "minscale": {
                         "type": "number", 
                         "metadata": {
-                            "deprecated": true, 
-                            "minVersion": 0, 
                             "maxVersion": 5.0
                         }
                     }, 
                     "labelminscaledenom": {
-                        "type": "number"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.0
+                        }
                     }, 
                     "data": {
-                        "type": "string"
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
                     }, 
                     "utfitem": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "minVersion": 7.0
+                        }
                     }, 
                     "maxgeowidth": {
-                        "type": "number"
-                    }, 
-                    "join": {
-                        "type": "object"
+                        "type": "number", 
+                        "metadata": {
+                            "minVersion": 5.4
+                        }
                     }, 
                     "name": {
                         "type": "string"
@@ -597,11 +989,17 @@
                     "tolerance": {
                         "type": "number"
                     }, 
+                    "plugin": {
+                        "type": "string"
+                    }, 
                     "styleitem": {
                         "type": "string"
                     }, 
                     "mask": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "minVersion": 6.2
+                        }
                     }, 
                     "offsite": {
                         "oneOf": [
@@ -616,7 +1014,7 @@
                                 "maxItems": 3
                             }, 
                             {
-                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                 "type": "string", 
                                 "example": "#aa33cc"
                             }
@@ -650,9 +1048,6 @@
                                 "^__[a-z]+__$": {}
                             }, 
                             "properties": {
-                                "size": {
-                                    "type": "integer"
-                                }, 
                                 "status": {
                                     "enum": [
                                         "on", 
@@ -661,23 +1056,30 @@
                                     "type": "string"
                                 }, 
                                 "color": {
-                                    "oneOf": [
+                                    "allOf": [
                                         {
-                                            "minItems": 3, 
-                                            "items": {
-                                                "minimum": -1, 
-                                                "type": "number", 
-                                                "maximum": 255
-                                            }, 
-                                            "type": "array", 
-                                            "maxItems": 3
-                                        }, 
-                                        {
-                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                            "type": "string", 
-                                            "example": "#aa33cc"
+                                            "oneOf": [
+                                                {
+                                                    "minItems": 3, 
+                                                    "items": {
+                                                        "minimum": -1, 
+                                                        "type": "number", 
+                                                        "maximum": 255
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 3
+                                                }, 
+                                                {
+                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                    "type": "string", 
+                                                    "example": "#aa33cc"
+                                                }
+                                            ]
                                         }
-                                    ]
+                                    ], 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "text": {
                                     "anyOf": [
@@ -705,7 +1107,8 @@
                                         }, 
                                         "properties": {
                                             "size": {
-                                                "oneOf": [
+                                                "default": 10, 
+                                                "anyOf": [
                                                     {
                                                         "type": "integer"
                                                     }, 
@@ -723,15 +1126,57 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
+                                                    }, 
+                                                    {
+                                                        "allOf": [
+                                                            {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\((.*?)\\)$", 
+                                                                        "type": "string", 
+                                                                        "description": "expression"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^/(.*?)/$", 
+                                                                        "type": "string", 
+                                                                        "description": "regex"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ], 
+                                                        "metadata": {
+                                                            "minVersion": 7.6
+                                                        }
                                                     }
                                                 ]
                                             }, 
                                             "force": {
-                                                "type": "boolean"
+                                                "oneOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    }, 
+                                                    {
+                                                        "enum": [
+                                                            "group"
+                                                        ], 
+                                                        "metadata": {
+                                                            "minVersion": 6.2
+                                                        }
+                                                    }
+                                                ]
                                             }, 
                                             "encoding": {
-                                                "type": "string"
+                                                "type": "string", 
+                                                "metadata": {
+                                                    "maxVersion": 7.6
+                                                }
                                             }, 
                                             "color": {
                                                 "oneOf": [
@@ -748,7 +1193,7 @@
                                                                 "maxItems": 3
                                                             }, 
                                                             {
-                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                 "type": "string", 
                                                                 "example": "#aa33cc"
                                                             }
@@ -757,33 +1202,46 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
                                             "text": {
-                                                "anyOf": [
+                                                "oneOf": [
                                                     {
-                                                        "type": "string"
-                                                    }, 
-                                                    {
-                                                        "pattern": "^\\((.*?)\\)$", 
-                                                        "type": "string", 
-                                                        "description": "expression"
-                                                    }, 
-                                                    {
-                                                        "pattern": "^/(.*?)/$", 
-                                                        "type": "string", 
-                                                        "description": "regex"
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            }, 
+                                                            {
+                                                                "pattern": "^\\((.*?)\\)$", 
+                                                                "type": "string", 
+                                                                "description": "expression"
+                                                            }, 
+                                                            {
+                                                                "pattern": "^/(.*?)/$", 
+                                                                "type": "string", 
+                                                                "description": "regex"
+                                                            }
+                                                        ]
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.2
+                                                }
                                             }, 
                                             "minsize": {
                                                 "type": "integer"
                                             }, 
                                             "repeatdistance": {
                                                 "default": 0, 
-                                                "type": "integer"
+                                                "type": "integer", 
+                                                "metadata": {
+                                                    "minVersion": 5.6
+                                                }
                                             }, 
                                             "wrap": {
                                                 "minLength": 1, 
@@ -791,19 +1249,25 @@
                                                 "maxLength": 1
                                             }, 
                                             "font": {
-                                                "oneOf": [
-                                                    {
-                                                        "type": "string"
-                                                    }, 
+                                                "anyOf": [
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.6
+                                                        }
+                                                    }, 
+                                                    {
+                                                        "type": "string"
                                                     }
                                                 ]
                                             }, 
                                             "minscaledenom": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "outlinecolor": {
                                                 "oneOf": [
@@ -820,7 +1284,7 @@
                                                                 "maxItems": 3
                                                             }, 
                                                             {
-                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                 "type": "string", 
                                                                 "example": "#aa33cc"
                                                             }
@@ -829,7 +1293,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -850,7 +1317,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -872,7 +1342,10 @@
                                                         "type": "string", 
                                                         "description": "attribute"
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 5.0
+                                                }
                                             }, 
                                             "maxsize": {
                                                 "type": "integer"
@@ -920,7 +1393,10 @@
                                                                 ], 
                                                                 "maxItems": 2
                                                             }, 
-                                                            "type": "array"
+                                                            "type": "array", 
+                                                            "metadata": {
+                                                                "minVersion": 6.2
+                                                            }
                                                         }, 
                                                         "color": {
                                                             "oneOf": [
@@ -937,7 +1413,7 @@
                                                                             "maxItems": 3
                                                                         }, 
                                                                         {
-                                                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                             "type": "string", 
                                                                             "example": "#aa33cc"
                                                                         }
@@ -946,7 +1422,10 @@
                                                                 {
                                                                     "pattern": "^\\[(.*?)\\]$", 
                                                                     "type": "string", 
-                                                                    "description": "attribute"
+                                                                    "description": "attribute", 
+                                                                    "metadata": {
+                                                                        "minVersion": 5.0
+                                                                    }
                                                                 }
                                                             ]
                                                         }, 
@@ -964,7 +1443,10 @@
                                                                 {
                                                                     "pattern": "^\\[(.*?)\\]$", 
                                                                     "type": "string", 
-                                                                    "description": "attribute"
+                                                                    "description": "attribute", 
+                                                                    "metadata": {
+                                                                        "minVersion": 5.0
+                                                                    }
                                                                 }
                                                             ]
                                                         }, 
@@ -993,7 +1475,10 @@
                                                                 "butt", 
                                                                 "round", 
                                                                 "square"
-                                                            ]
+                                                            ], 
+                                                            "metadata": {
+                                                                "minVersion": 6.0
+                                                            }
                                                         }, 
                                                         "__type__": {
                                                             "enum": [
@@ -1008,7 +1493,10 @@
                                                                 {
                                                                     "pattern": "^\\[(.*?)\\]$", 
                                                                     "type": "string", 
-                                                                    "description": "attribute"
+                                                                    "description": "attribute", 
+                                                                    "metadata": {
+                                                                        "minVersion": 5.4
+                                                                    }
                                                                 }
                                                             ]
                                                         }, 
@@ -1033,7 +1521,10 @@
                                                                     "type": "string", 
                                                                     "description": "expression"
                                                                 }
-                                                            ]
+                                                            ], 
+                                                            "metadata": {
+                                                                "minVersion": 5.4
+                                                            }
                                                         }, 
                                                         "outlinewidth": {
                                                             "oneOf": [
@@ -1045,7 +1536,10 @@
                                                                     "type": "string", 
                                                                     "description": "attribute"
                                                                 }
-                                                            ]
+                                                            ], 
+                                                            "metadata": {
+                                                                "minVersion": 5.4
+                                                            }
                                                         }, 
                                                         "include": {
                                                             "items": {
@@ -1061,7 +1555,10 @@
                                                                 {
                                                                     "pattern": "^\\[(.*?)\\]$", 
                                                                     "type": "string", 
-                                                                    "description": "attribute"
+                                                                    "description": "attribute", 
+                                                                    "metadata": {
+                                                                        "minVersion": 5.6
+                                                                    }
                                                                 }
                                                             ]
                                                         }, 
@@ -1096,7 +1593,10 @@
                                                                                 }
                                                                             ], 
                                                                             "type": "array", 
-                                                                            "maxItems": 2
+                                                                            "maxItems": 2, 
+                                                                            "metadata": {
+                                                                                "minVersion": 6.2
+                                                                            }
                                                                         }, 
                                                                         "name": {
                                                                             "type": "string"
@@ -1110,12 +1610,24 @@
                                                                             "type": "string"
                                                                         }, 
                                                                         "character": {
-                                                                            "minLength": 1, 
-                                                                            "type": "string", 
-                                                                            "maxLength": 1
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "minLength": 1, 
+                                                                                    "type": "string", 
+                                                                                    "maxLength": 1
+                                                                                }, 
+                                                                                {
+                                                                                    "pattern": "^&#[0-9]+;$", 
+                                                                                    "type": "string", 
+                                                                                    "example": "&#10140;"
+                                                                                }
+                                                                            ]
                                                                         }, 
                                                                         "antialias": {
-                                                                            "type": "boolean"
+                                                                            "type": "boolean", 
+                                                                            "metadata": {
+                                                                                "maxVersion": 7.6
+                                                                            }
                                                                         }, 
                                                                         "points": {
                                                                             "items": {
@@ -1141,7 +1653,7 @@
                                                                                     "maxItems": 3
                                                                                 }, 
                                                                                 {
-                                                                                    "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                                     "type": "string", 
                                                                                     "example": "#aa33cc"
                                                                                 }
@@ -1161,7 +1673,10 @@
                                                                             ]
                                                                         }, 
                                                                         "transparent": {
-                                                                            "type": "integer"
+                                                                            "type": "integer", 
+                                                                            "metadata": {
+                                                                                "maxVersion": 7.6
+                                                                            }
                                                                         }, 
                                                                         "filled": {
                                                                             "type": "boolean"
@@ -1171,40 +1686,65 @@
                                                             ]
                                                         }, 
                                                         "linejoinmaxsize": {
-                                                            "type": "integer"
+                                                            "type": "integer", 
+                                                            "metadata": {
+                                                                "minVersion": 6.0
+                                                            }
                                                         }, 
                                                         "antialias": {
-                                                            "type": "boolean"
+                                                            "type": "boolean", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
                                                         }, 
                                                         "gap": {
-                                                            "type": "number"
+                                                            "type": "number", 
+                                                            "metadata": {
+                                                                "minVersion": 6.0
+                                                            }
                                                         }, 
                                                         "backgroundcolor": {
-                                                            "oneOf": [
+                                                            "allOf": [
                                                                 {
-                                                                    "minItems": 3, 
-                                                                    "items": {
-                                                                        "minimum": -1, 
-                                                                        "type": "number", 
-                                                                        "maximum": 255
-                                                                    }, 
-                                                                    "type": "array", 
-                                                                    "maxItems": 3
-                                                                }, 
-                                                                {
-                                                                    "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                                                    "type": "string", 
-                                                                    "example": "#aa33cc"
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "minItems": 3, 
+                                                                            "items": {
+                                                                                "minimum": -1, 
+                                                                                "type": "number", 
+                                                                                "maximum": 255
+                                                                            }, 
+                                                                            "type": "array", 
+                                                                            "maxItems": 3
+                                                                        }, 
+                                                                        {
+                                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                            "type": "string", 
+                                                                            "example": "#aa33cc"
+                                                                        }
+                                                                    ]
                                                                 }
-                                                            ]
+                                                            ], 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
                                                         }, 
                                                         "offset": {
-                                                            "minItems": 2, 
                                                             "items": {
-                                                                "type": "number"
+                                                                "minItems": 2, 
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute"
+                                                                    }
+                                                                ], 
+                                                                "maxItems": 2
                                                             }, 
-                                                            "type": "array", 
-                                                            "maxItems": 2
+                                                            "type": "array"
                                                         }, 
                                                         "linejoin": {
                                                             "enum": [
@@ -1212,7 +1752,10 @@
                                                                 "miter", 
                                                                 "bevel", 
                                                                 "none"
-                                                            ]
+                                                            ], 
+                                                            "metadata": {
+                                                                "minVersion": 6.0
+                                                            }
                                                         }, 
                                                         "rangeitem": {
                                                             "pattern": "^\\[(.*?)\\]$", 
@@ -1243,7 +1786,10 @@
                                                             "type": "number"
                                                         }, 
                                                         "initialgap": {
-                                                            "type": "number"
+                                                            "type": "number", 
+                                                            "metadata": {
+                                                                "minVersion": 6.2
+                                                            }
                                                         }, 
                                                         "datarange": {
                                                             "minItems": 2, 
@@ -1254,21 +1800,34 @@
                                                             "maxItems": 2
                                                         }, 
                                                         "maxscaledenom": {
-                                                            "type": "number"
+                                                            "type": "number", 
+                                                            "metadata": {
+                                                                "minVersion": 5.0
+                                                            }
                                                         }, 
                                                         "angleitem": {
-                                                            "type": "string"
+                                                            "type": "string", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
                                                         }, 
                                                         "pattern": {
-                                                            "items": {
-                                                                "items": {
-                                                                    "minItems": 2, 
-                                                                    "type": "number", 
-                                                                    "maxItems": 2
-                                                                }, 
-                                                                "type": "array"
-                                                            }, 
-                                                            "type": "array"
+                                                            "allOf": [
+                                                                {
+                                                                    "items": {
+                                                                        "items": {
+                                                                            "minItems": 2, 
+                                                                            "type": "number", 
+                                                                            "maxItems": 2
+                                                                        }, 
+                                                                        "type": "array"
+                                                                    }, 
+                                                                    "type": "array"
+                                                                }
+                                                            ], 
+                                                            "metadata": {
+                                                                "minVersion": 6.0
+                                                            }
                                                         }, 
                                                         "outlinecolor": {
                                                             "oneOf": [
@@ -1285,7 +1844,7 @@
                                                                             "maxItems": 3
                                                                         }, 
                                                                         {
-                                                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                             "type": "string", 
                                                                             "example": "#aa33cc"
                                                                         }
@@ -1294,7 +1853,10 @@
                                                                 {
                                                                     "pattern": "^\\[(.*?)\\]$", 
                                                                     "type": "string", 
-                                                                    "description": "attribute"
+                                                                    "description": "attribute", 
+                                                                    "metadata": {
+                                                                        "minVersion": 5.0
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1307,6 +1869,24 @@
                                             }, 
                                             "antialias": {
                                                 "type": "boolean"
+                                            }, 
+                                            "backgroundshadowsize": {
+                                                "allOf": [
+                                                    {
+                                                        "items": {
+                                                            "items": {
+                                                                "minItems": 2, 
+                                                                "type": "number", 
+                                                                "maxItems": 2
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "type": "array"
+                                                    }
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "shadowcolor": {
                                                 "oneOf": [
@@ -1321,38 +1901,92 @@
                                                         "maxItems": 3
                                                     }, 
                                                     {
-                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                        "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                         "type": "string", 
                                                         "example": "#aa33cc"
                                                     }
                                                 ]
                                             }, 
                                             "backgroundcolor": {
+                                                "allOf": [
+                                                    {
+                                                        "oneOf": [
+                                                            {
+                                                                "minItems": 3, 
+                                                                "items": {
+                                                                    "minimum": -1, 
+                                                                    "type": "number", 
+                                                                    "maximum": 255
+                                                                }, 
+                                                                "type": "array", 
+                                                                "maxItems": 3
+                                                            }, 
+                                                            {
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                "type": "string", 
+                                                                "example": "#aa33cc"
+                                                            }
+                                                        ]
+                                                    }
+                                                ], 
+                                                "metadata": {
+                                                    "maxVersion": 6.0
+                                                }
+                                            }, 
+                                            "offset": {
+                                                "default": [
+                                                    0, 
+                                                    0
+                                                ], 
                                                 "oneOf": [
                                                     {
-                                                        "minItems": 3, 
+                                                        "minItems": 2, 
                                                         "items": {
-                                                            "minimum": -1, 
-                                                            "type": "number", 
-                                                            "maximum": 255
+                                                            "type": "number"
                                                         }, 
                                                         "type": "array", 
-                                                        "maxItems": 3
+                                                        "maxItems": 2
                                                     }, 
                                                     {
-                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                                        "type": "string", 
-                                                        "example": "#aa33cc"
+                                                        "minItems": 2, 
+                                                        "items": {
+                                                            "pattern": "^\\[(.*?)\\]$", 
+                                                            "type": "string", 
+                                                            "description": "attribute"
+                                                        }, 
+                                                        "type": "array", 
+                                                        "maxItems": 2, 
+                                                        "metadata": {
+                                                            "minVersion": 7.6
+                                                        }
                                                     }
                                                 ]
                                             }, 
-                                            "offset": {
-                                                "minItems": 2, 
-                                                "items": {
-                                                    "type": "number"
-                                                }, 
-                                                "type": "array", 
-                                                "maxItems": 2
+                                            "backgroundshadowcolor": {
+                                                "allOf": [
+                                                    {
+                                                        "oneOf": [
+                                                            {
+                                                                "minItems": 3, 
+                                                                "items": {
+                                                                    "minimum": -1, 
+                                                                    "type": "number", 
+                                                                    "maximum": 255
+                                                                }, 
+                                                                "type": "array", 
+                                                                "maxItems": 3
+                                                            }, 
+                                                            {
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                "type": "string", 
+                                                                "example": "#aa33cc"
+                                                            }
+                                                        ]
+                                                    }
+                                                ], 
+                                                "metadata": {
+                                                    "maxVersion": 6.0
+                                                }
                                             }, 
                                             "minfeaturesize": {
                                                 "oneOf": [
@@ -1367,9 +2001,16 @@
                                                 ]
                                             }, 
                                             "maxoverlapangle": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "shadowsize": {
+                                                "default": [
+                                                    1, 
+                                                    1
+                                                ], 
                                                 "oneOf": [
                                                     {
                                                         "minItems": 2, 
@@ -1392,26 +2033,48 @@
                                                             }
                                                         ], 
                                                         "type": "array", 
-                                                        "maxItems": 2
+                                                        "maxItems": 2, 
+                                                        "metadata": {
+                                                            "minVersion": 6.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
                                             "align": {
-                                                "additionalProperties": false, 
-                                                "enum": [
-                                                    "left", 
-                                                    "center", 
-                                                    "right"
+                                                "oneOf": [
+                                                    {
+                                                        "additionalProperties": false, 
+                                                        "enum": [
+                                                            "left", 
+                                                            "center", 
+                                                            "right"
+                                                        ], 
+                                                        "type": "string"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
+                                                    }
                                                 ], 
-                                                "type": "string"
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "maxscaledenom": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "maxlength": {
-                                                "type": "integer"
+                                                "type": "integer", 
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "position": {
+                                                "default": "cc", 
                                                 "oneOf": [
                                                     {
                                                         "enum": [
@@ -1430,65 +2093,88 @@
                                                             "lc", 
                                                             "lr"
                                                         ]
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
                                                     }
                                                 ]
                                             }, 
                                             "expression": {
-                                                "anyOf": [
+                                                "allOf": [
                                                     {
-                                                        "type": "string"
-                                                    }, 
-                                                    {
-                                                        "pattern": "^\\((.*?)\\)$", 
-                                                        "type": "string", 
-                                                        "description": "expression"
-                                                    }, 
-                                                    {
-                                                        "pattern": "^/(.*?)/$", 
-                                                        "type": "string", 
-                                                        "description": "regex"
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            }, 
+                                                            {
+                                                                "pattern": "^\\((.*?)\\)$", 
+                                                                "type": "string", 
+                                                                "description": "expression"
+                                                            }, 
+                                                            {
+                                                                "pattern": "^/(.*?)/$", 
+                                                                "type": "string", 
+                                                                "description": "regex"
+                                                            }
+                                                        ]
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.2
+                                                }
                                             }
                                         }
                                     }, 
                                     "type": "array"
                                 }, 
                                 "maxscale": {
-                                    "deprecated": true, 
-                                    "type": "number"
+                                    "type": "number", 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "minsize": {
-                                    "type": "integer"
+                                    "type": "integer", 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "minscaledenom": {
                                     "type": "number"
                                 }, 
                                 "outlinecolor": {
-                                    "oneOf": [
+                                    "allOf": [
                                         {
-                                            "minItems": 3, 
-                                            "items": {
-                                                "minimum": -1, 
-                                                "type": "number", 
-                                                "maximum": 255
-                                            }, 
-                                            "type": "array", 
-                                            "maxItems": 3
-                                        }, 
-                                        {
-                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                            "type": "string", 
-                                            "example": "#aa33cc"
+                                            "oneOf": [
+                                                {
+                                                    "minItems": 3, 
+                                                    "items": {
+                                                        "minimum": -1, 
+                                                        "type": "number", 
+                                                        "maximum": 255
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 3
+                                                }, 
+                                                {
+                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                    "type": "string", 
+                                                    "example": "#aa33cc"
+                                                }
+                                            ]
                                         }
-                                    ]
+                                    ], 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "group": {
                                     "type": "string"
                                 }, 
                                 "title": {
-                                    "type": "string", 
-                                    "description": "missing"
+                                    "type": "string"
                                 }, 
                                 "__type__": {
                                     "enum": [
@@ -1496,258 +2182,62 @@
                                     ]
                                 }, 
                                 "maxsize": {
-                                    "type": "integer"
+                                    "type": "integer", 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "template": {
                                     "type": "string", 
                                     "description": "filename"
                                 }, 
-                                "include": {
-                                    "items": {
-                                        "type": "string"
-                                    }, 
-                                    "type": "array"
+                                "size": {
+                                    "type": "integer", 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "leader": {
-                                    "additionalProperties": false, 
-                                    "type": "object", 
-                                    "patternProperties": {
-                                        "^__[a-z]+__$": {}
-                                    }, 
-                                    "properties": {
-                                        "styles": {
-                                            "minItems": 1, 
-                                            "items": {
-                                                "additionalProperties": false, 
-                                                "type": "object", 
-                                                "patternProperties": {
-                                                    "^__[a-z]+__$": {}
-                                                }, 
-                                                "properties": {
-                                                    "polaroffset": {
-                                                        "items": {
-                                                            "minItems": 2, 
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "number"
-                                                                }, 
-                                                                {
-                                                                    "pattern": "^\\[(.*?)\\]$", 
-                                                                    "type": "string", 
-                                                                    "description": "attribute"
-                                                                }
-                                                            ], 
-                                                            "maxItems": 2
+                                    "allOf": [
+                                        {
+                                            "additionalProperties": false, 
+                                            "type": "object", 
+                                            "patternProperties": {
+                                                "^__[a-z]+__$": {}
+                                            }, 
+                                            "properties": {
+                                                "styles": {
+                                                    "minItems": 1, 
+                                                    "items": {
+                                                        "additionalProperties": false, 
+                                                        "type": "object", 
+                                                        "patternProperties": {
+                                                            "^__[a-z]+__$": {}
                                                         }, 
-                                                        "type": "array"
-                                                    }, 
-                                                    "color": {
-                                                        "oneOf": [
-                                                            {
+                                                        "properties": {
+                                                            "polaroffset": {
+                                                                "items": {
+                                                                    "minItems": 2, 
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        }, 
+                                                                        {
+                                                                            "pattern": "^\\[(.*?)\\]$", 
+                                                                            "type": "string", 
+                                                                            "description": "attribute"
+                                                                        }
+                                                                    ], 
+                                                                    "maxItems": 2
+                                                                }, 
+                                                                "type": "array", 
+                                                                "metadata": {
+                                                                    "minVersion": 6.2
+                                                                }
+                                                            }, 
+                                                            "color": {
                                                                 "oneOf": [
                                                                     {
-                                                                        "minItems": 3, 
-                                                                        "items": {
-                                                                            "minimum": -1, 
-                                                                            "type": "number", 
-                                                                            "maximum": 255
-                                                                        }, 
-                                                                        "type": "array", 
-                                                                        "maxItems": 3
-                                                                    }, 
-                                                                    {
-                                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                                                        "type": "string", 
-                                                                        "example": "#aa33cc"
-                                                                    }
-                                                                ]
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "minwidth": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "minscaledenom": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "size": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "number"
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "angle": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "number"
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }, 
-                                                            {
-                                                                "enum": [
-                                                                    "auto"
-                                                                ]
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "maxwidth": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "linecap": {
-                                                        "enum": [
-                                                            "butt", 
-                                                            "round", 
-                                                            "square"
-                                                        ]
-                                                    }, 
-                                                    "__type__": {
-                                                        "enum": [
-                                                            "style"
-                                                        ]
-                                                    }, 
-                                                    "width": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "number"
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "maxsize": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "geomtransform": {
-                                                        "oneOf": [
-                                                            {
-                                                                "enum": [
-                                                                    "bbox", 
-                                                                    "centroid", 
-                                                                    "end", 
-                                                                    "labelpnt", 
-                                                                    "labelpoly", 
-                                                                    "start", 
-                                                                    "vertices"
-                                                                ]
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\((.*?)\\)$", 
-                                                                "type": "string", 
-                                                                "description": "expression"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "outlinewidth": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "number"
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "include": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        }, 
-                                                        "type": "array"
-                                                    }, 
-                                                    "opacity": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "integer"
-                                                            }, 
-                                                            {
-                                                                "pattern": "^\\[(.*?)\\]$", 
-                                                                "type": "string", 
-                                                                "description": "attribute"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "symbol": {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "string"
-                                                            }, 
-                                                            {
-                                                                "type": "number"
-                                                            }, 
-                                                            {
-                                                                "additionalProperties": false, 
-                                                                "type": "object", 
-                                                                "patternProperties": {
-                                                                    "^__[a-z]+__$": {}
-                                                                }, 
-                                                                "properties": {
-                                                                    "include": {
-                                                                        "items": {
-                                                                            "type": "string"
-                                                                        }, 
-                                                                        "type": "array"
-                                                                    }, 
-                                                                    "anchorpoint": {
-                                                                        "minItems": 2, 
-                                                                        "items": [
-                                                                            {
-                                                                                "minimum": 0, 
-                                                                                "type": "number", 
-                                                                                "maximum": 1
-                                                                            }
-                                                                        ], 
-                                                                        "type": "array", 
-                                                                        "maxItems": 2
-                                                                    }, 
-                                                                    "name": {
-                                                                        "type": "string"
-                                                                    }, 
-                                                                    "__type__": {
-                                                                        "enum": [
-                                                                            "symbol"
-                                                                        ]
-                                                                    }, 
-                                                                    "image": {
-                                                                        "type": "string"
-                                                                    }, 
-                                                                    "character": {
-                                                                        "minLength": 1, 
-                                                                        "type": "string", 
-                                                                        "maxLength": 1
-                                                                    }, 
-                                                                    "antialias": {
-                                                                        "type": "boolean"
-                                                                    }, 
-                                                                    "points": {
-                                                                        "items": {
-                                                                            "items": {
-                                                                                "minItems": 2, 
-                                                                                "type": "number", 
-                                                                                "maxItems": 2
-                                                                            }, 
-                                                                            "type": "array"
-                                                                        }, 
-                                                                        "type": "array"
-                                                                    }, 
-                                                                    "backgroundcolor": {
                                                                         "oneOf": [
                                                                             {
                                                                                 "minItems": 3, 
@@ -1760,186 +2250,486 @@
                                                                                 "maxItems": 3
                                                                             }, 
                                                                             {
-                                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                                 "type": "string", 
                                                                                 "example": "#aa33cc"
                                                                             }
                                                                         ]
                                                                     }, 
-                                                                    "font": {
-                                                                        "type": "string"
-                                                                    }, 
-                                                                    "type": {
-                                                                        "enum": [
-                                                                            "ellipse", 
-                                                                            "hatch", 
-                                                                            "pixmap", 
-                                                                            "svg", 
-                                                                            "truetype", 
-                                                                            "vector"
-                                                                        ]
-                                                                    }, 
-                                                                    "transparent": {
-                                                                        "type": "integer"
-                                                                    }, 
-                                                                    "filled": {
-                                                                        "type": "boolean"
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "linejoinmaxsize": {
-                                                        "type": "integer"
-                                                    }, 
-                                                    "antialias": {
-                                                        "type": "boolean"
-                                                    }, 
-                                                    "gap": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "backgroundcolor": {
-                                                        "oneOf": [
-                                                            {
-                                                                "minItems": 3, 
-                                                                "items": {
-                                                                    "minimum": -1, 
-                                                                    "type": "number", 
-                                                                    "maximum": 255
-                                                                }, 
-                                                                "type": "array", 
-                                                                "maxItems": 3
-                                                            }, 
-                                                            {
-                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                                                "type": "string", 
-                                                                "example": "#aa33cc"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "offset": {
-                                                        "minItems": 2, 
-                                                        "items": {
-                                                            "type": "number"
-                                                        }, 
-                                                        "type": "array", 
-                                                        "maxItems": 2
-                                                    }, 
-                                                    "linejoin": {
-                                                        "enum": [
-                                                            "round", 
-                                                            "miter", 
-                                                            "bevel", 
-                                                            "none"
-                                                        ]
-                                                    }, 
-                                                    "rangeitem": {
-                                                        "pattern": "^\\[(.*?)\\]$", 
-                                                        "type": "string", 
-                                                        "description": "attribute"
-                                                    }, 
-                                                    "colorrange": {
-                                                        "oneOf": [
-                                                            {
-                                                                "minItems": 6, 
-                                                                "items": {
-                                                                    "type": "integer"
-                                                                }, 
-                                                                "type": "array", 
-                                                                "maxItems": 6
-                                                            }, 
-                                                            {
-                                                                "minItems": 2, 
-                                                                "items": {
-                                                                    "type": "string"
-                                                                }, 
-                                                                "type": "array", 
-                                                                "maxItems": 2
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "minsize": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "initialgap": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "datarange": {
-                                                        "minItems": 2, 
-                                                        "items": {
-                                                            "type": "number"
-                                                        }, 
-                                                        "type": "array", 
-                                                        "maxItems": 2
-                                                    }, 
-                                                    "maxscaledenom": {
-                                                        "type": "number"
-                                                    }, 
-                                                    "angleitem": {
-                                                        "type": "string"
-                                                    }, 
-                                                    "pattern": {
-                                                        "items": {
-                                                            "items": {
-                                                                "minItems": 2, 
-                                                                "type": "number", 
-                                                                "maxItems": 2
-                                                            }, 
-                                                            "type": "array"
-                                                        }, 
-                                                        "type": "array"
-                                                    }, 
-                                                    "outlinecolor": {
-                                                        "oneOf": [
-                                                            {
-                                                                "oneOf": [
                                                                     {
-                                                                        "minItems": 3, 
-                                                                        "items": {
-                                                                            "minimum": -1, 
-                                                                            "type": "number", 
-                                                                            "maximum": 255
-                                                                        }, 
-                                                                        "type": "array", 
-                                                                        "maxItems": 3
-                                                                    }, 
-                                                                    {
-                                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                        "pattern": "^\\[(.*?)\\]$", 
                                                                         "type": "string", 
-                                                                        "example": "#aa33cc"
+                                                                        "description": "attribute", 
+                                                                        "metadata": {
+                                                                            "minVersion": 5.0
+                                                                        }
                                                                     }
                                                                 ]
                                                             }, 
-                                                            {
+                                                            "minwidth": {
+                                                                "type": "number"
+                                                            }, 
+                                                            "minscaledenom": {
+                                                                "type": "number"
+                                                            }, 
+                                                            "size": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute", 
+                                                                        "metadata": {
+                                                                            "minVersion": 5.0
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "angle": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute"
+                                                                    }, 
+                                                                    {
+                                                                        "enum": [
+                                                                            "auto"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "maxwidth": {
+                                                                "type": "number"
+                                                            }, 
+                                                            "linecap": {
+                                                                "enum": [
+                                                                    "butt", 
+                                                                    "round", 
+                                                                    "square"
+                                                                ], 
+                                                                "metadata": {
+                                                                    "minVersion": 6.0
+                                                                }
+                                                            }, 
+                                                            "__type__": {
+                                                                "enum": [
+                                                                    "style"
+                                                                ]
+                                                            }, 
+                                                            "width": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute", 
+                                                                        "metadata": {
+                                                                            "minVersion": 5.4
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "maxsize": {
+                                                                "type": "number"
+                                                            }, 
+                                                            "geomtransform": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "bbox", 
+                                                                            "centroid", 
+                                                                            "end", 
+                                                                            "labelpnt", 
+                                                                            "labelpoly", 
+                                                                            "start", 
+                                                                            "vertices"
+                                                                        ]
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\((.*?)\\)$", 
+                                                                        "type": "string", 
+                                                                        "description": "expression"
+                                                                    }
+                                                                ], 
+                                                                "metadata": {
+                                                                    "minVersion": 5.4
+                                                                }
+                                                            }, 
+                                                            "outlinewidth": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute"
+                                                                    }
+                                                                ], 
+                                                                "metadata": {
+                                                                    "minVersion": 5.4
+                                                                }
+                                                            }, 
+                                                            "include": {
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }, 
+                                                                "type": "array"
+                                                            }, 
+                                                            "opacity": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute", 
+                                                                        "metadata": {
+                                                                            "minVersion": 5.6
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "symbol": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    }, 
+                                                                    {
+                                                                        "type": "number"
+                                                                    }, 
+                                                                    {
+                                                                        "additionalProperties": false, 
+                                                                        "type": "object", 
+                                                                        "patternProperties": {
+                                                                            "^__[a-z]+__$": {}
+                                                                        }, 
+                                                                        "properties": {
+                                                                            "include": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                }, 
+                                                                                "type": "array"
+                                                                            }, 
+                                                                            "anchorpoint": {
+                                                                                "minItems": 2, 
+                                                                                "items": [
+                                                                                    {
+                                                                                        "minimum": 0, 
+                                                                                        "type": "number", 
+                                                                                        "maximum": 1
+                                                                                    }
+                                                                                ], 
+                                                                                "type": "array", 
+                                                                                "maxItems": 2, 
+                                                                                "metadata": {
+                                                                                    "minVersion": 6.2
+                                                                                }
+                                                                            }, 
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }, 
+                                                                            "__type__": {
+                                                                                "enum": [
+                                                                                    "symbol"
+                                                                                ]
+                                                                            }, 
+                                                                            "image": {
+                                                                                "type": "string"
+                                                                            }, 
+                                                                            "character": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "minLength": 1, 
+                                                                                        "type": "string", 
+                                                                                        "maxLength": 1
+                                                                                    }, 
+                                                                                    {
+                                                                                        "pattern": "^&#[0-9]+;$", 
+                                                                                        "type": "string", 
+                                                                                        "example": "&#10140;"
+                                                                                    }
+                                                                                ]
+                                                                            }, 
+                                                                            "antialias": {
+                                                                                "type": "boolean", 
+                                                                                "metadata": {
+                                                                                    "maxVersion": 7.6
+                                                                                }
+                                                                            }, 
+                                                                            "points": {
+                                                                                "items": {
+                                                                                    "items": {
+                                                                                        "minItems": 2, 
+                                                                                        "type": "number", 
+                                                                                        "maxItems": 2
+                                                                                    }, 
+                                                                                    "type": "array"
+                                                                                }, 
+                                                                                "type": "array"
+                                                                            }, 
+                                                                            "backgroundcolor": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "minItems": 3, 
+                                                                                        "items": {
+                                                                                            "minimum": -1, 
+                                                                                            "type": "number", 
+                                                                                            "maximum": 255
+                                                                                        }, 
+                                                                                        "type": "array", 
+                                                                                        "maxItems": 3
+                                                                                    }, 
+                                                                                    {
+                                                                                        "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                                        "type": "string", 
+                                                                                        "example": "#aa33cc"
+                                                                                    }
+                                                                                ]
+                                                                            }, 
+                                                                            "font": {
+                                                                                "type": "string"
+                                                                            }, 
+                                                                            "type": {
+                                                                                "enum": [
+                                                                                    "ellipse", 
+                                                                                    "hatch", 
+                                                                                    "pixmap", 
+                                                                                    "svg", 
+                                                                                    "truetype", 
+                                                                                    "vector"
+                                                                                ]
+                                                                            }, 
+                                                                            "transparent": {
+                                                                                "type": "integer", 
+                                                                                "metadata": {
+                                                                                    "maxVersion": 7.6
+                                                                                }
+                                                                            }, 
+                                                                            "filled": {
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "linejoinmaxsize": {
+                                                                "type": "integer", 
+                                                                "metadata": {
+                                                                    "minVersion": 6.0
+                                                                }
+                                                            }, 
+                                                            "antialias": {
+                                                                "type": "boolean", 
+                                                                "metadata": {
+                                                                    "maxVersion": 7.6
+                                                                }
+                                                            }, 
+                                                            "gap": {
+                                                                "type": "number", 
+                                                                "metadata": {
+                                                                    "minVersion": 6.0
+                                                                }
+                                                            }, 
+                                                            "backgroundcolor": {
+                                                                "allOf": [
+                                                                    {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "minItems": 3, 
+                                                                                "items": {
+                                                                                    "minimum": -1, 
+                                                                                    "type": "number", 
+                                                                                    "maximum": 255
+                                                                                }, 
+                                                                                "type": "array", 
+                                                                                "maxItems": 3
+                                                                            }, 
+                                                                            {
+                                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                                "type": "string", 
+                                                                                "example": "#aa33cc"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ], 
+                                                                "metadata": {
+                                                                    "maxVersion": 7.6
+                                                                }
+                                                            }, 
+                                                            "offset": {
+                                                                "items": {
+                                                                    "minItems": 2, 
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        }, 
+                                                                        {
+                                                                            "pattern": "^\\[(.*?)\\]$", 
+                                                                            "type": "string", 
+                                                                            "description": "attribute"
+                                                                        }
+                                                                    ], 
+                                                                    "maxItems": 2
+                                                                }, 
+                                                                "type": "array"
+                                                            }, 
+                                                            "linejoin": {
+                                                                "enum": [
+                                                                    "round", 
+                                                                    "miter", 
+                                                                    "bevel", 
+                                                                    "none"
+                                                                ], 
+                                                                "metadata": {
+                                                                    "minVersion": 6.0
+                                                                }
+                                                            }, 
+                                                            "rangeitem": {
                                                                 "pattern": "^\\[(.*?)\\]$", 
                                                                 "type": "string", 
                                                                 "description": "attribute"
+                                                            }, 
+                                                            "colorrange": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "minItems": 6, 
+                                                                        "items": {
+                                                                            "type": "integer"
+                                                                        }, 
+                                                                        "type": "array", 
+                                                                        "maxItems": 6
+                                                                    }, 
+                                                                    {
+                                                                        "minItems": 2, 
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }, 
+                                                                        "type": "array", 
+                                                                        "maxItems": 2
+                                                                    }
+                                                                ]
+                                                            }, 
+                                                            "minsize": {
+                                                                "type": "number"
+                                                            }, 
+                                                            "initialgap": {
+                                                                "type": "number", 
+                                                                "metadata": {
+                                                                    "minVersion": 6.2
+                                                                }
+                                                            }, 
+                                                            "datarange": {
+                                                                "minItems": 2, 
+                                                                "items": {
+                                                                    "type": "number"
+                                                                }, 
+                                                                "type": "array", 
+                                                                "maxItems": 2
+                                                            }, 
+                                                            "maxscaledenom": {
+                                                                "type": "number", 
+                                                                "metadata": {
+                                                                    "minVersion": 5.0
+                                                                }
+                                                            }, 
+                                                            "angleitem": {
+                                                                "type": "string", 
+                                                                "metadata": {
+                                                                    "maxVersion": 7.6
+                                                                }
+                                                            }, 
+                                                            "pattern": {
+                                                                "allOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "items": {
+                                                                                "minItems": 2, 
+                                                                                "type": "number", 
+                                                                                "maxItems": 2
+                                                                            }, 
+                                                                            "type": "array"
+                                                                        }, 
+                                                                        "type": "array"
+                                                                    }
+                                                                ], 
+                                                                "metadata": {
+                                                                    "minVersion": 6.0
+                                                                }
+                                                            }, 
+                                                            "outlinecolor": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "minItems": 3, 
+                                                                                "items": {
+                                                                                    "minimum": -1, 
+                                                                                    "type": "number", 
+                                                                                    "maximum": 255
+                                                                                }, 
+                                                                                "type": "array", 
+                                                                                "maxItems": 3
+                                                                            }, 
+                                                                            {
+                                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                                "type": "string", 
+                                                                                "example": "#aa33cc"
+                                                                            }
+                                                                        ]
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                                        "type": "string", 
+                                                                        "description": "attribute", 
+                                                                        "metadata": {
+                                                                            "minVersion": 5.0
+                                                                        }
+                                                                    }
+                                                                ]
                                                             }
-                                                        ]
-                                                    }
+                                                        }
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 1
+                                                }, 
+                                                "__type__": {
+                                                    "enum": [
+                                                        "leader"
+                                                    ]
+                                                }, 
+                                                "include": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    }, 
+                                                    "type": "array"
+                                                }, 
+                                                "maxdistance": {
+                                                    "type": "integer"
+                                                }, 
+                                                "gridstep": {
+                                                    "type": "integer"
                                                 }
-                                            }, 
-                                            "type": "array", 
-                                            "maxItems": 1
-                                        }, 
-                                        "__type__": {
-                                            "enum": [
-                                                "leader"
-                                            ]
-                                        }, 
-                                        "include": {
-                                            "items": {
-                                                "type": "string"
-                                            }, 
-                                            "type": "array"
-                                        }, 
-                                        "maxdistance": {
-                                            "type": "integer"
-                                        }, 
-                                        "gridstep": {
-                                            "type": "integer"
+                                            }
                                         }
+                                    ], 
+                                    "metadata": {
+                                        "minVersion": 6.2
                                     }
+                                }, 
+                                "metadata": {
+                                    "additionalProperties": true, 
+                                    "type": "object", 
+                                    "properties": {}
                                 }, 
                                 "styles": {
                                     "items": {
@@ -1964,7 +2754,10 @@
                                                     ], 
                                                     "maxItems": 2
                                                 }, 
-                                                "type": "array"
+                                                "type": "array", 
+                                                "metadata": {
+                                                    "minVersion": 6.2
+                                                }
                                             }, 
                                             "color": {
                                                 "oneOf": [
@@ -1981,7 +2774,7 @@
                                                                 "maxItems": 3
                                                             }, 
                                                             {
-                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                 "type": "string", 
                                                                 "example": "#aa33cc"
                                                             }
@@ -1990,7 +2783,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -2008,7 +2804,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -2037,7 +2836,10 @@
                                                     "butt", 
                                                     "round", 
                                                     "square"
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "__type__": {
                                                 "enum": [
@@ -2052,7 +2854,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.4
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -2077,7 +2882,10 @@
                                                         "type": "string", 
                                                         "description": "expression"
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "outlinewidth": {
                                                 "oneOf": [
@@ -2089,7 +2897,10 @@
                                                         "type": "string", 
                                                         "description": "attribute"
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 5.4
+                                                }
                                             }, 
                                             "include": {
                                                 "items": {
@@ -2105,7 +2916,10 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.6
+                                                        }
                                                     }
                                                 ]
                                             }, 
@@ -2140,7 +2954,10 @@
                                                                     }
                                                                 ], 
                                                                 "type": "array", 
-                                                                "maxItems": 2
+                                                                "maxItems": 2, 
+                                                                "metadata": {
+                                                                    "minVersion": 6.2
+                                                                }
                                                             }, 
                                                             "name": {
                                                                 "type": "string"
@@ -2154,12 +2971,24 @@
                                                                 "type": "string"
                                                             }, 
                                                             "character": {
-                                                                "minLength": 1, 
-                                                                "type": "string", 
-                                                                "maxLength": 1
+                                                                "oneOf": [
+                                                                    {
+                                                                        "minLength": 1, 
+                                                                        "type": "string", 
+                                                                        "maxLength": 1
+                                                                    }, 
+                                                                    {
+                                                                        "pattern": "^&#[0-9]+;$", 
+                                                                        "type": "string", 
+                                                                        "example": "&#10140;"
+                                                                    }
+                                                                ]
                                                             }, 
                                                             "antialias": {
-                                                                "type": "boolean"
+                                                                "type": "boolean", 
+                                                                "metadata": {
+                                                                    "maxVersion": 7.6
+                                                                }
                                                             }, 
                                                             "points": {
                                                                 "items": {
@@ -2185,7 +3014,7 @@
                                                                         "maxItems": 3
                                                                     }, 
                                                                     {
-                                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                        "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                         "type": "string", 
                                                                         "example": "#aa33cc"
                                                                     }
@@ -2205,7 +3034,10 @@
                                                                 ]
                                                             }, 
                                                             "transparent": {
-                                                                "type": "integer"
+                                                                "type": "integer", 
+                                                                "metadata": {
+                                                                    "maxVersion": 7.6
+                                                                }
                                                             }, 
                                                             "filled": {
                                                                 "type": "boolean"
@@ -2215,40 +3047,65 @@
                                                 ]
                                             }, 
                                             "linejoinmaxsize": {
-                                                "type": "integer"
+                                                "type": "integer", 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "antialias": {
-                                                "type": "boolean"
+                                                "type": "boolean", 
+                                                "metadata": {
+                                                    "maxVersion": 7.6
+                                                }
                                             }, 
                                             "gap": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "backgroundcolor": {
-                                                "oneOf": [
+                                                "allOf": [
                                                     {
-                                                        "minItems": 3, 
-                                                        "items": {
-                                                            "minimum": -1, 
-                                                            "type": "number", 
-                                                            "maximum": 255
-                                                        }, 
-                                                        "type": "array", 
-                                                        "maxItems": 3
-                                                    }, 
-                                                    {
-                                                        "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                                        "type": "string", 
-                                                        "example": "#aa33cc"
+                                                        "oneOf": [
+                                                            {
+                                                                "minItems": 3, 
+                                                                "items": {
+                                                                    "minimum": -1, 
+                                                                    "type": "number", 
+                                                                    "maximum": 255
+                                                                }, 
+                                                                "type": "array", 
+                                                                "maxItems": 3
+                                                            }, 
+                                                            {
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                "type": "string", 
+                                                                "example": "#aa33cc"
+                                                            }
+                                                        ]
                                                     }
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "maxVersion": 7.6
+                                                }
                                             }, 
                                             "offset": {
-                                                "minItems": 2, 
                                                 "items": {
-                                                    "type": "number"
+                                                    "minItems": 2, 
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "number"
+                                                        }, 
+                                                        {
+                                                            "pattern": "^\\[(.*?)\\]$", 
+                                                            "type": "string", 
+                                                            "description": "attribute"
+                                                        }
+                                                    ], 
+                                                    "maxItems": 2
                                                 }, 
-                                                "type": "array", 
-                                                "maxItems": 2
+                                                "type": "array"
                                             }, 
                                             "linejoin": {
                                                 "enum": [
@@ -2256,7 +3113,10 @@
                                                     "miter", 
                                                     "bevel", 
                                                     "none"
-                                                ]
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "rangeitem": {
                                                 "pattern": "^\\[(.*?)\\]$", 
@@ -2287,7 +3147,10 @@
                                                 "type": "number"
                                             }, 
                                             "initialgap": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 6.2
+                                                }
                                             }, 
                                             "datarange": {
                                                 "minItems": 2, 
@@ -2298,21 +3161,34 @@
                                                 "maxItems": 2
                                             }, 
                                             "maxscaledenom": {
-                                                "type": "number"
+                                                "type": "number", 
+                                                "metadata": {
+                                                    "minVersion": 5.0
+                                                }
                                             }, 
                                             "angleitem": {
-                                                "type": "string"
+                                                "type": "string", 
+                                                "metadata": {
+                                                    "maxVersion": 7.6
+                                                }
                                             }, 
                                             "pattern": {
-                                                "items": {
-                                                    "items": {
-                                                        "minItems": 2, 
-                                                        "type": "number", 
-                                                        "maxItems": 2
-                                                    }, 
-                                                    "type": "array"
-                                                }, 
-                                                "type": "array"
+                                                "allOf": [
+                                                    {
+                                                        "items": {
+                                                            "items": {
+                                                                "minItems": 2, 
+                                                                "type": "number", 
+                                                                "maxItems": 2
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "type": "array"
+                                                    }
+                                                ], 
+                                                "metadata": {
+                                                    "minVersion": 6.0
+                                                }
                                             }, 
                                             "outlinecolor": {
                                                 "oneOf": [
@@ -2329,7 +3205,7 @@
                                                                 "maxItems": 3
                                                             }, 
                                                             {
-                                                                "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                                 "type": "string", 
                                                                 "example": "#aa33cc"
                                                             }
@@ -2338,13 +3214,19 @@
                                                     {
                                                         "pattern": "^\\[(.*?)\\]$", 
                                                         "type": "string", 
-                                                        "description": "attribute"
+                                                        "description": "attribute", 
+                                                        "metadata": {
+                                                            "minVersion": 5.0
+                                                        }
                                                     }
                                                 ]
                                             }
                                         }
                                     }, 
-                                    "type": "array"
+                                    "type": "array", 
+                                    "metadata": {
+                                        "minVersion": 4.0
+                                    }
                                 }, 
                                 "keyimage": {
                                     "type": "string", 
@@ -2381,7 +3263,10 @@
                                                         }
                                                     ], 
                                                     "type": "array", 
-                                                    "maxItems": 2
+                                                    "maxItems": 2, 
+                                                    "metadata": {
+                                                        "minVersion": 6.2
+                                                    }
                                                 }, 
                                                 "name": {
                                                     "type": "string"
@@ -2395,12 +3280,24 @@
                                                     "type": "string"
                                                 }, 
                                                 "character": {
-                                                    "minLength": 1, 
-                                                    "type": "string", 
-                                                    "maxLength": 1
+                                                    "oneOf": [
+                                                        {
+                                                            "minLength": 1, 
+                                                            "type": "string", 
+                                                            "maxLength": 1
+                                                        }, 
+                                                        {
+                                                            "pattern": "^&#[0-9]+;$", 
+                                                            "type": "string", 
+                                                            "example": "&#10140;"
+                                                        }
+                                                    ]
                                                 }, 
                                                 "antialias": {
-                                                    "type": "boolean"
+                                                    "type": "boolean", 
+                                                    "metadata": {
+                                                        "maxVersion": 7.6
+                                                    }
                                                 }, 
                                                 "points": {
                                                     "items": {
@@ -2426,7 +3323,7 @@
                                                             "maxItems": 3
                                                         }, 
                                                         {
-                                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                                                             "type": "string", 
                                                             "example": "#aa33cc"
                                                         }
@@ -2446,43 +3343,70 @@
                                                     ]
                                                 }, 
                                                 "transparent": {
-                                                    "type": "integer"
+                                                    "type": "integer", 
+                                                    "metadata": {
+                                                        "maxVersion": 7.6
+                                                    }
                                                 }, 
                                                 "filled": {
                                                     "type": "boolean"
                                                 }
                                             }
                                         }
-                                    ]
+                                    ], 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "backgroundcolor": {
-                                    "oneOf": [
+                                    "allOf": [
                                         {
-                                            "minItems": 3, 
-                                            "items": {
-                                                "minimum": -1, 
-                                                "type": "number", 
-                                                "maximum": 255
-                                            }, 
-                                            "type": "array", 
-                                            "maxItems": 3
-                                        }, 
-                                        {
-                                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
-                                            "type": "string", 
-                                            "example": "#aa33cc"
+                                            "oneOf": [
+                                                {
+                                                    "minItems": 3, 
+                                                    "items": {
+                                                        "minimum": -1, 
+                                                        "type": "number", 
+                                                        "maximum": 255
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 3
+                                                }, 
+                                                {
+                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                    "type": "string", 
+                                                    "example": "#aa33cc"
+                                                }
+                                            ]
                                         }
-                                    ]
+                                    ], 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
                                 }, 
                                 "minscale": {
-                                    "deprecated": true, 
+                                    "type": "number", 
+                                    "metadata": {
+                                        "maxVersion": 7.6
+                                    }
+                                }, 
+                                "minfeaturesize": {
                                     "type": "number"
+                                }, 
+                                "include": {
+                                    "items": {
+                                        "type": "string"
+                                    }, 
+                                    "type": "array"
                                 }, 
                                 "name": {
                                     "type": "string"
                                 }, 
                                 "maxscaledenom": {
-                                    "type": "number"
+                                    "type": "number", 
+                                    "metadata": {
+                                        "minVersion": 5.0
+                                    }
                                 }, 
                                 "debug": {
                                     "enum": [
@@ -2518,7 +3442,10 @@
                         "type": "array"
                     }, 
                     "labelsizeitem": {
-                        "type": "string"
+                        "type": "string", 
+                        "metadata": {
+                            "maxVersion": 5.0
+                        }
                     }, 
                     "transparency": {
                         "oneOf": [
@@ -2530,22 +3457,32 @@
                                     "alpha"
                                 ]
                             }
-                        ]
+                        ], 
+                        "metadata": {
+                            "maxVersion": 7.6
+                        }
                     }, 
                     "__position__": {
                         "type": "object"
                     }, 
                     "debug": {
-                        "enum": [
-                            "on", 
-                            "off", 
-                            0, 
-                            1, 
-                            2, 
-                            3, 
-                            4, 
-                            5
-                        ]
+                        "allOf": [
+                            {
+                                "enum": [
+                                    "on", 
+                                    "off", 
+                                    0, 
+                                    1, 
+                                    2, 
+                                    3, 
+                                    4, 
+                                    5
+                                ]
+                            }
+                        ], 
+                        "metadata": {
+                            "minVersion": 5.0
+                        }
                     }, 
                     "composites": {
                         "items": {
@@ -2574,7 +3511,10 @@
                                 }
                             }
                         }, 
-                        "type": "array"
+                        "type": "array", 
+                        "metadata": {
+                            "minVersion": 7.0
+                        }
                     }, 
                     "validation": {
                         "additionalProperties": true, 
@@ -2592,7 +3532,121 @@
             "type": "array"
         }, 
         "web": {
-            "type": "object"
+            "additionalProperties": false, 
+            "type": "object", 
+            "patternProperties": {
+                "^__[a-z]+__$": {}
+            }, 
+            "properties": {
+                "queryformat": {
+                    "type": "string", 
+                    "description": "mime-type"
+                }, 
+                "temppath": {
+                    "type": "string", 
+                    "description": "path", 
+                    "metadata": {
+                        "minVersion": 6.0
+                    }
+                }, 
+                "maxscale": {
+                    "type": "number", 
+                    "metadata": {
+                        "maxVersion": 7.6
+                    }
+                }, 
+                "header": {
+                    "type": "string", 
+                    "description": "filename"
+                }, 
+                "minscaledenom": {
+                    "type": "number", 
+                    "metadata": {
+                        "minVersion": 5.0
+                    }
+                }, 
+                "imagepath": {
+                    "type": "string", 
+                    "description": "path"
+                }, 
+                "log": {
+                    "type": "string", 
+                    "description": "filename", 
+                    "metadata": {
+                        "maxVersion": 8.0
+                    }
+                }, 
+                "mintemplate": {
+                    "type": "string"
+                }, 
+                "__type__": {
+                    "enum": [
+                        "web"
+                    ]
+                }, 
+                "template": {
+                    "type": "string"
+                }, 
+                "include": {
+                    "items": {
+                        "type": "string"
+                    }, 
+                    "type": "array"
+                }, 
+                "empty": {
+                    "type": "string"
+                }, 
+                "metadata": {
+                    "additionalProperties": true, 
+                    "type": "object", 
+                    "properties": {}
+                }, 
+                "imageurl": {
+                    "type": "string", 
+                    "description": "url"
+                }, 
+                "maxtemplate": {
+                    "type": "string"
+                }, 
+                "browseformat": {
+                    "type": "string", 
+                    "description": "mime-type", 
+                    "metadata": {
+                        "minVersion": 4.8
+                    }
+                }, 
+                "minscale": {
+                    "type": "number", 
+                    "metadata": {
+                        "maxVersion": 7.6
+                    }
+                }, 
+                "footer": {
+                    "type": "string", 
+                    "description": "filename"
+                }, 
+                "maxscaledenom": {
+                    "type": "number", 
+                    "metadata": {
+                        "minVersion": 5.0
+                    }
+                }, 
+                "legendformat": {
+                    "type": "string", 
+                    "description": "mime-type", 
+                    "metadata": {
+                        "minVersion": 4.8
+                    }
+                }, 
+                "error": {
+                    "type": "string"
+                }, 
+                "validation": {
+                    "additionalProperties": true, 
+                    "type": "object", 
+                    "properties": {}
+                }
+            }
         }, 
         "angle": {
             "type": "number"
@@ -2601,11 +3655,18 @@
             "type": "string"
         }, 
         "interlace": {
-            "enum": [
-                "on", 
-                "off"
+            "oneOf": [
+                {
+                    "enum": [
+                        "on", 
+                        "off"
+                    ], 
+                    "type": "string"
+                }
             ], 
-            "type": "string"
+            "metadata": {
+                "maxVersion": 7.6
+            }
         }, 
         "symbolset": {
             "type": "string"
@@ -2674,7 +3735,1259 @@
             "type": "string"
         }, 
         "scalebar": {
-            "type": "object"
+            "additionalProperties": false, 
+            "type": "object", 
+            "patternProperties": {
+                "^__[a-z]+__$": {}
+            }, 
+            "properties": {
+                "size": {
+                    "default": [
+                        200, 
+                        3
+                    ], 
+                    "items": {
+                        "type": "integer"
+                    }, 
+                    "type": "array", 
+                    "minItems": 2, 
+                    "maxItems": 2
+                }, 
+                "backgroundcolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "color": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "image": {
+                    "type": "string", 
+                    "description": "filename"
+                }, 
+                "labels": {
+                    "minItems": 0, 
+                    "items": {
+                        "additionalProperties": false, 
+                        "type": "object", 
+                        "patternProperties": {
+                            "^__[a-z]+__$": {}
+                        }, 
+                        "properties": {
+                            "size": {
+                                "default": 10, 
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "tiny", 
+                                            "small", 
+                                            "medium", 
+                                            "large", 
+                                            "giant"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }, 
+                                    {
+                                        "allOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\((.*?)\\)$", 
+                                                        "type": "string", 
+                                                        "description": "expression"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^/(.*?)/$", 
+                                                        "type": "string", 
+                                                        "description": "regex"
+                                                    }
+                                                ]
+                                            }
+                                        ], 
+                                        "metadata": {
+                                            "minVersion": 7.6
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "force": {
+                                "oneOf": [
+                                    {
+                                        "type": "boolean"
+                                    }, 
+                                    {
+                                        "enum": [
+                                            "group"
+                                        ], 
+                                        "metadata": {
+                                            "minVersion": 6.2
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "encoding": {
+                                "type": "string", 
+                                "metadata": {
+                                    "maxVersion": 7.6
+                                }
+                            }, 
+                            "color": {
+                                "oneOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "text": {
+                                "oneOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.2
+                                }
+                            }, 
+                            "minsize": {
+                                "type": "integer"
+                            }, 
+                            "repeatdistance": {
+                                "default": 0, 
+                                "type": "integer", 
+                                "metadata": {
+                                    "minVersion": 5.6
+                                }
+                            }, 
+                            "wrap": {
+                                "minLength": 1, 
+                                "type": "string", 
+                                "maxLength": 1
+                            }, 
+                            "font": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.6
+                                        }
+                                    }, 
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }, 
+                            "minscaledenom": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "outlinecolor": {
+                                "oneOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "angle": {
+                                "oneOf": [
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "auto", 
+                                            "auto2", 
+                                            "follow"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "type": "number"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "__type__": {
+                                "enum": [
+                                    "label"
+                                ]
+                            }, 
+                            "partials": {
+                                "type": "boolean"
+                            }, 
+                            "priority": {
+                                "oneOf": [
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 5.0
+                                }
+                            }, 
+                            "maxsize": {
+                                "type": "integer"
+                            }, 
+                            "mindistance": {
+                                "type": "integer"
+                            }, 
+                            "outlinewidth": {
+                                "type": "integer"
+                            }, 
+                            "include": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "type": {
+                                "additionalProperties": false, 
+                                "enum": [
+                                    "bitmap", 
+                                    "truetype"
+                                ], 
+                                "type": "string"
+                            }, 
+                            "styles": {
+                                "items": {
+                                    "additionalProperties": false, 
+                                    "type": "object", 
+                                    "patternProperties": {
+                                        "^__[a-z]+__$": {}
+                                    }, 
+                                    "properties": {
+                                        "polaroffset": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "oneOf": [
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
+                                                    }
+                                                ], 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array", 
+                                            "metadata": {
+                                                "minVersion": 6.2
+                                            }
+                                        }, 
+                                        "color": {
+                                            "oneOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "minwidth": {
+                                            "type": "number"
+                                        }, 
+                                        "minscaledenom": {
+                                            "type": "number"
+                                        }, 
+                                        "size": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "angle": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute"
+                                                }, 
+                                                {
+                                                    "enum": [
+                                                        "auto"
+                                                    ]
+                                                }
+                                            ]
+                                        }, 
+                                        "maxwidth": {
+                                            "type": "number"
+                                        }, 
+                                        "linecap": {
+                                            "enum": [
+                                                "butt", 
+                                                "round", 
+                                                "square"
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "__type__": {
+                                            "enum": [
+                                                "style"
+                                            ]
+                                        }, 
+                                        "width": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.4
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "maxsize": {
+                                            "type": "number"
+                                        }, 
+                                        "geomtransform": {
+                                            "oneOf": [
+                                                {
+                                                    "enum": [
+                                                        "bbox", 
+                                                        "centroid", 
+                                                        "end", 
+                                                        "labelpnt", 
+                                                        "labelpoly", 
+                                                        "start", 
+                                                        "vertices"
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\((.*?)\\)$", 
+                                                    "type": "string", 
+                                                    "description": "expression"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 5.4
+                                            }
+                                        }, 
+                                        "outlinewidth": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 5.4
+                                            }
+                                        }, 
+                                        "include": {
+                                            "items": {
+                                                "type": "string"
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "opacity": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.6
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "symbol": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                }, 
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "additionalProperties": false, 
+                                                    "type": "object", 
+                                                    "patternProperties": {
+                                                        "^__[a-z]+__$": {}
+                                                    }, 
+                                                    "properties": {
+                                                        "include": {
+                                                            "items": {
+                                                                "type": "string"
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "anchorpoint": {
+                                                            "minItems": 2, 
+                                                            "items": [
+                                                                {
+                                                                    "minimum": 0, 
+                                                                    "type": "number", 
+                                                                    "maximum": 1
+                                                                }
+                                                            ], 
+                                                            "type": "array", 
+                                                            "maxItems": 2, 
+                                                            "metadata": {
+                                                                "minVersion": 6.2
+                                                            }
+                                                        }, 
+                                                        "name": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "__type__": {
+                                                            "enum": [
+                                                                "symbol"
+                                                            ]
+                                                        }, 
+                                                        "image": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "character": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "minLength": 1, 
+                                                                    "type": "string", 
+                                                                    "maxLength": 1
+                                                                }, 
+                                                                {
+                                                                    "pattern": "^&#[0-9]+;$", 
+                                                                    "type": "string", 
+                                                                    "example": "&#10140;"
+                                                                }
+                                                            ]
+                                                        }, 
+                                                        "antialias": {
+                                                            "type": "boolean", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
+                                                        }, 
+                                                        "points": {
+                                                            "items": {
+                                                                "items": {
+                                                                    "minItems": 2, 
+                                                                    "type": "number", 
+                                                                    "maxItems": 2
+                                                                }, 
+                                                                "type": "array"
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "backgroundcolor": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "minItems": 3, 
+                                                                    "items": {
+                                                                        "minimum": -1, 
+                                                                        "type": "number", 
+                                                                        "maximum": 255
+                                                                    }, 
+                                                                    "type": "array", 
+                                                                    "maxItems": 3
+                                                                }, 
+                                                                {
+                                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                    "type": "string", 
+                                                                    "example": "#aa33cc"
+                                                                }
+                                                            ]
+                                                        }, 
+                                                        "font": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "type": {
+                                                            "enum": [
+                                                                "ellipse", 
+                                                                "hatch", 
+                                                                "pixmap", 
+                                                                "svg", 
+                                                                "truetype", 
+                                                                "vector"
+                                                            ]
+                                                        }, 
+                                                        "transparent": {
+                                                            "type": "integer", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
+                                                        }, 
+                                                        "filled": {
+                                                            "type": "boolean"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "linejoinmaxsize": {
+                                            "type": "integer", 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "antialias": {
+                                            "type": "boolean", 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "gap": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "backgroundcolor": {
+                                            "allOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "offset": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "oneOf": [
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
+                                                    }
+                                                ], 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "linejoin": {
+                                            "enum": [
+                                                "round", 
+                                                "miter", 
+                                                "bevel", 
+                                                "none"
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "rangeitem": {
+                                            "pattern": "^\\[(.*?)\\]$", 
+                                            "type": "string", 
+                                            "description": "attribute"
+                                        }, 
+                                        "colorrange": {
+                                            "oneOf": [
+                                                {
+                                                    "minItems": 6, 
+                                                    "items": {
+                                                        "type": "integer"
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 6
+                                                }, 
+                                                {
+                                                    "minItems": 2, 
+                                                    "items": {
+                                                        "type": "string"
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 2
+                                                }
+                                            ]
+                                        }, 
+                                        "minsize": {
+                                            "type": "number"
+                                        }, 
+                                        "initialgap": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 6.2
+                                            }
+                                        }, 
+                                        "datarange": {
+                                            "minItems": 2, 
+                                            "items": {
+                                                "type": "number"
+                                            }, 
+                                            "type": "array", 
+                                            "maxItems": 2
+                                        }, 
+                                        "maxscaledenom": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 5.0
+                                            }
+                                        }, 
+                                        "angleitem": {
+                                            "type": "string", 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "pattern": {
+                                            "allOf": [
+                                                {
+                                                    "items": {
+                                                        "items": {
+                                                            "minItems": 2, 
+                                                            "type": "number", 
+                                                            "maxItems": 2
+                                                        }, 
+                                                        "type": "array"
+                                                    }, 
+                                                    "type": "array"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "outlinecolor": {
+                                            "oneOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }, 
+                                "type": "array"
+                            }, 
+                            "buffer": {
+                                "type": "integer"
+                            }, 
+                            "antialias": {
+                                "type": "boolean"
+                            }, 
+                            "backgroundshadowsize": {
+                                "allOf": [
+                                    {
+                                        "items": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "type": "number", 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "type": "array"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.0
+                                }
+                            }, 
+                            "shadowcolor": {
+                                "oneOf": [
+                                    {
+                                        "minItems": 3, 
+                                        "items": {
+                                            "minimum": -1, 
+                                            "type": "number", 
+                                            "maximum": 255
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 3
+                                    }, 
+                                    {
+                                        "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                        "type": "string", 
+                                        "example": "#aa33cc"
+                                    }
+                                ]
+                            }, 
+                            "backgroundcolor": {
+                                "allOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "maxVersion": 6.0
+                                }
+                            }, 
+                            "offset": {
+                                "default": [
+                                    0, 
+                                    0
+                                ], 
+                                "oneOf": [
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "type": "number"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2
+                                    }, 
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "pattern": "^\\[(.*?)\\]$", 
+                                            "type": "string", 
+                                            "description": "attribute"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2, 
+                                        "metadata": {
+                                            "minVersion": 7.6
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "backgroundshadowcolor": {
+                                "allOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "maxVersion": 6.0
+                                }
+                            }, 
+                            "minfeaturesize": {
+                                "oneOf": [
+                                    {
+                                        "enum": [
+                                            "auto"
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "integer"
+                                    }
+                                ]
+                            }, 
+                            "maxoverlapangle": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 6.0
+                                }
+                            }, 
+                            "shadowsize": {
+                                "default": [
+                                    1, 
+                                    1
+                                ], 
+                                "oneOf": [
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "type": "integer"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2
+                                    }, 
+                                    {
+                                        "minItems": 2, 
+                                        "items": [
+                                            {
+                                                "type": "integer"
+                                            }, 
+                                            {
+                                                "pattern": "^\\[(.*?)\\]$", 
+                                                "type": "string", 
+                                                "description": "attribute"
+                                            }
+                                        ], 
+                                        "type": "array", 
+                                        "maxItems": 2, 
+                                        "metadata": {
+                                            "minVersion": 6.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "align": {
+                                "oneOf": [
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "left", 
+                                            "center", 
+                                            "right"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "maxscaledenom": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "maxlength": {
+                                "type": "integer", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "position": {
+                                "default": "cc", 
+                                "oneOf": [
+                                    {
+                                        "enum": [
+                                            "auto"
+                                        ]
+                                    }, 
+                                    {
+                                        "enum": [
+                                            "ul", 
+                                            "uc", 
+                                            "ur", 
+                                            "cl", 
+                                            "cc", 
+                                            "cr", 
+                                            "ll", 
+                                            "lc", 
+                                            "lr"
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ]
+                            }, 
+                            "expression": {
+                                "allOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.2
+                                }
+                            }
+                        }
+                    }, 
+                    "type": "array", 
+                    "maxItems": 1
+                }, 
+                "intervals": {
+                    "default": 4, 
+                    "type": "integer"
+                }, 
+                "marker": {
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }, 
+                "outlinecolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "postlabelcache": {
+                    "type": "boolean"
+                }, 
+                "style": {
+                    "type": "integer"
+                }, 
+                "__type__": {
+                    "enum": [
+                        "scalebar"
+                    ]
+                }, 
+                "interlace": {
+                    "type": "boolean", 
+                    "metadata": {
+                        "maxVersion": 7.6
+                    }
+                }, 
+                "units": {
+                    "enum": [
+                        "feet", 
+                        "inches", 
+                        "kilometers", 
+                        "meters", 
+                        "miles", 
+                        "nauticalmiles", 
+                        "pixels"
+                    ]
+                }, 
+                "include": {
+                    "items": {
+                        "type": "string"
+                    }, 
+                    "type": "array"
+                }, 
+                "status": {
+                    "deafult": "off", 
+                    "enum": [
+                        "on", 
+                        "off", 
+                        "embed"
+                    ], 
+                    "type": "string"
+                }, 
+                "markersize": {
+                    "type": "integer"
+                }, 
+                "maxboxsize": {
+                    "type": "integer"
+                }, 
+                "extent": {
+                    "minItems": 4, 
+                    "items": {
+                        "type": "number"
+                    }, 
+                    "type": "array", 
+                    "maxItems": 4
+                }, 
+                "offset": {
+                    "minItems": 2, 
+                    "items": {
+                        "type": "integer"
+                    }, 
+                    "type": "array", 
+                    "maxItems": 2, 
+                    "metadata": {
+                        "minVersion": 7.2
+                    }
+                }, 
+                "transparent": {
+                    "allOf": [
+                        {
+                            "enum": [
+                                "on", 
+                                "off"
+                            ], 
+                            "type": "string"
+                        }
+                    ]
+                }, 
+                "minboxsize": {
+                    "type": "integer"
+                }, 
+                "align": {
+                    "additionalProperties": false, 
+                    "enum": [
+                        "left", 
+                        "center", 
+                        "right"
+                    ], 
+                    "type": "string", 
+                    "metadata": {
+                        "minVersion": 5.2
+                    }
+                }, 
+                "position": {
+                    "enum": [
+                        "ul", 
+                        "uc", 
+                        "ur", 
+                        "cl", 
+                        "cc", 
+                        "cr", 
+                        "ll", 
+                        "lc", 
+                        "lr"
+                    ]
+                }, 
+                "imagecolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }
+            }
         }, 
         "shapepath": {
             "type": "string"
@@ -2691,6 +5004,7 @@
             "type": "number"
         }, 
         "name": {
+            "default": "MS", 
             "type": "string"
         }, 
         "querymap": {
@@ -2708,6 +5022,7 @@
                     "type": "string"
                 }, 
                 "style": {
+                    "default": "hilite", 
                     "additionalProperties": false, 
                     "enum": [
                         "normal", 
@@ -2729,7 +5044,7 @@
                             "maxItems": 3
                         }, 
                         {
-                            "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                             "type": "string", 
                             "example": "#aa33cc"
                         }
@@ -2747,11 +5062,15 @@
                     "type": "array"
                 }, 
                 "size": {
-                    "minItems": 2, 
+                    "default": [
+                        -1, 
+                        -1
+                    ], 
                     "items": {
                         "type": "integer"
                     }, 
                     "type": "array", 
+                    "minItems": 2, 
                     "maxItems": 2
                 }
             }
@@ -2769,7 +5088,7 @@
                     "maxItems": 3
                 }, 
                 {
-                    "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$", 
+                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
                     "type": "string", 
                     "example": "#aa33cc"
                 }
@@ -2779,25 +5098,1204 @@
             "type": "string"
         }, 
         "legend": {
-            "type": "object"
+            "additionalProperties": false, 
+            "type": "object", 
+            "patternProperties": {
+                "^__[a-z]+__$": {}
+            }, 
+            "properties": {
+                "postlabelcache": {
+                    "type": "boolean"
+                }, 
+                "status": {
+                    "default": "off", 
+                    "enum": [
+                        "on", 
+                        "off", 
+                        "embed"
+                    ], 
+                    "type": "string"
+                }, 
+                "imagecolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }, 
+                "labels": {
+                    "minItems": 0, 
+                    "items": {
+                        "additionalProperties": false, 
+                        "type": "object", 
+                        "patternProperties": {
+                            "^__[a-z]+__$": {}
+                        }, 
+                        "properties": {
+                            "size": {
+                                "default": 10, 
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "tiny", 
+                                            "small", 
+                                            "medium", 
+                                            "large", 
+                                            "giant"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }, 
+                                    {
+                                        "allOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\((.*?)\\)$", 
+                                                        "type": "string", 
+                                                        "description": "expression"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^/(.*?)/$", 
+                                                        "type": "string", 
+                                                        "description": "regex"
+                                                    }
+                                                ]
+                                            }
+                                        ], 
+                                        "metadata": {
+                                            "minVersion": 7.6
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "force": {
+                                "oneOf": [
+                                    {
+                                        "type": "boolean"
+                                    }, 
+                                    {
+                                        "enum": [
+                                            "group"
+                                        ], 
+                                        "metadata": {
+                                            "minVersion": 6.2
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "encoding": {
+                                "type": "string", 
+                                "metadata": {
+                                    "maxVersion": 7.6
+                                }
+                            }, 
+                            "color": {
+                                "oneOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "text": {
+                                "oneOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.2
+                                }
+                            }, 
+                            "minsize": {
+                                "type": "integer"
+                            }, 
+                            "repeatdistance": {
+                                "default": 0, 
+                                "type": "integer", 
+                                "metadata": {
+                                    "minVersion": 5.6
+                                }
+                            }, 
+                            "wrap": {
+                                "minLength": 1, 
+                                "type": "string", 
+                                "maxLength": 1
+                            }, 
+                            "font": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.6
+                                        }
+                                    }, 
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }, 
+                            "minscaledenom": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "outlinecolor": {
+                                "oneOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "angle": {
+                                "oneOf": [
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "auto", 
+                                            "auto2", 
+                                            "follow"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "type": "number"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute", 
+                                        "metadata": {
+                                            "minVersion": 5.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "__type__": {
+                                "enum": [
+                                    "label"
+                                ]
+                            }, 
+                            "partials": {
+                                "type": "boolean"
+                            }, 
+                            "priority": {
+                                "oneOf": [
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 5.0
+                                }
+                            }, 
+                            "maxsize": {
+                                "type": "integer"
+                            }, 
+                            "mindistance": {
+                                "type": "integer"
+                            }, 
+                            "outlinewidth": {
+                                "type": "integer"
+                            }, 
+                            "include": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "type": {
+                                "additionalProperties": false, 
+                                "enum": [
+                                    "bitmap", 
+                                    "truetype"
+                                ], 
+                                "type": "string"
+                            }, 
+                            "styles": {
+                                "items": {
+                                    "additionalProperties": false, 
+                                    "type": "object", 
+                                    "patternProperties": {
+                                        "^__[a-z]+__$": {}
+                                    }, 
+                                    "properties": {
+                                        "polaroffset": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "oneOf": [
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
+                                                    }
+                                                ], 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array", 
+                                            "metadata": {
+                                                "minVersion": 6.2
+                                            }
+                                        }, 
+                                        "color": {
+                                            "oneOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "minwidth": {
+                                            "type": "number"
+                                        }, 
+                                        "minscaledenom": {
+                                            "type": "number"
+                                        }, 
+                                        "size": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "angle": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute"
+                                                }, 
+                                                {
+                                                    "enum": [
+                                                        "auto"
+                                                    ]
+                                                }
+                                            ]
+                                        }, 
+                                        "maxwidth": {
+                                            "type": "number"
+                                        }, 
+                                        "linecap": {
+                                            "enum": [
+                                                "butt", 
+                                                "round", 
+                                                "square"
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "__type__": {
+                                            "enum": [
+                                                "style"
+                                            ]
+                                        }, 
+                                        "width": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.4
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "maxsize": {
+                                            "type": "number"
+                                        }, 
+                                        "geomtransform": {
+                                            "oneOf": [
+                                                {
+                                                    "enum": [
+                                                        "bbox", 
+                                                        "centroid", 
+                                                        "end", 
+                                                        "labelpnt", 
+                                                        "labelpoly", 
+                                                        "start", 
+                                                        "vertices"
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\((.*?)\\)$", 
+                                                    "type": "string", 
+                                                    "description": "expression"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 5.4
+                                            }
+                                        }, 
+                                        "outlinewidth": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 5.4
+                                            }
+                                        }, 
+                                        "include": {
+                                            "items": {
+                                                "type": "string"
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "opacity": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer"
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.6
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "symbol": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                }, 
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "additionalProperties": false, 
+                                                    "type": "object", 
+                                                    "patternProperties": {
+                                                        "^__[a-z]+__$": {}
+                                                    }, 
+                                                    "properties": {
+                                                        "include": {
+                                                            "items": {
+                                                                "type": "string"
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "anchorpoint": {
+                                                            "minItems": 2, 
+                                                            "items": [
+                                                                {
+                                                                    "minimum": 0, 
+                                                                    "type": "number", 
+                                                                    "maximum": 1
+                                                                }
+                                                            ], 
+                                                            "type": "array", 
+                                                            "maxItems": 2, 
+                                                            "metadata": {
+                                                                "minVersion": 6.2
+                                                            }
+                                                        }, 
+                                                        "name": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "__type__": {
+                                                            "enum": [
+                                                                "symbol"
+                                                            ]
+                                                        }, 
+                                                        "image": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "character": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "minLength": 1, 
+                                                                    "type": "string", 
+                                                                    "maxLength": 1
+                                                                }, 
+                                                                {
+                                                                    "pattern": "^&#[0-9]+;$", 
+                                                                    "type": "string", 
+                                                                    "example": "&#10140;"
+                                                                }
+                                                            ]
+                                                        }, 
+                                                        "antialias": {
+                                                            "type": "boolean", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
+                                                        }, 
+                                                        "points": {
+                                                            "items": {
+                                                                "items": {
+                                                                    "minItems": 2, 
+                                                                    "type": "number", 
+                                                                    "maxItems": 2
+                                                                }, 
+                                                                "type": "array"
+                                                            }, 
+                                                            "type": "array"
+                                                        }, 
+                                                        "backgroundcolor": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "minItems": 3, 
+                                                                    "items": {
+                                                                        "minimum": -1, 
+                                                                        "type": "number", 
+                                                                        "maximum": 255
+                                                                    }, 
+                                                                    "type": "array", 
+                                                                    "maxItems": 3
+                                                                }, 
+                                                                {
+                                                                    "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                                    "type": "string", 
+                                                                    "example": "#aa33cc"
+                                                                }
+                                                            ]
+                                                        }, 
+                                                        "font": {
+                                                            "type": "string"
+                                                        }, 
+                                                        "type": {
+                                                            "enum": [
+                                                                "ellipse", 
+                                                                "hatch", 
+                                                                "pixmap", 
+                                                                "svg", 
+                                                                "truetype", 
+                                                                "vector"
+                                                            ]
+                                                        }, 
+                                                        "transparent": {
+                                                            "type": "integer", 
+                                                            "metadata": {
+                                                                "maxVersion": 7.6
+                                                            }
+                                                        }, 
+                                                        "filled": {
+                                                            "type": "boolean"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }, 
+                                        "linejoinmaxsize": {
+                                            "type": "integer", 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "antialias": {
+                                            "type": "boolean", 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "gap": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "backgroundcolor": {
+                                            "allOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "offset": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "oneOf": [
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "pattern": "^\\[(.*?)\\]$", 
+                                                        "type": "string", 
+                                                        "description": "attribute"
+                                                    }
+                                                ], 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "linejoin": {
+                                            "enum": [
+                                                "round", 
+                                                "miter", 
+                                                "bevel", 
+                                                "none"
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "rangeitem": {
+                                            "pattern": "^\\[(.*?)\\]$", 
+                                            "type": "string", 
+                                            "description": "attribute"
+                                        }, 
+                                        "colorrange": {
+                                            "oneOf": [
+                                                {
+                                                    "minItems": 6, 
+                                                    "items": {
+                                                        "type": "integer"
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 6
+                                                }, 
+                                                {
+                                                    "minItems": 2, 
+                                                    "items": {
+                                                        "type": "string"
+                                                    }, 
+                                                    "type": "array", 
+                                                    "maxItems": 2
+                                                }
+                                            ]
+                                        }, 
+                                        "minsize": {
+                                            "type": "number"
+                                        }, 
+                                        "initialgap": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 6.2
+                                            }
+                                        }, 
+                                        "datarange": {
+                                            "minItems": 2, 
+                                            "items": {
+                                                "type": "number"
+                                            }, 
+                                            "type": "array", 
+                                            "maxItems": 2
+                                        }, 
+                                        "maxscaledenom": {
+                                            "type": "number", 
+                                            "metadata": {
+                                                "minVersion": 5.0
+                                            }
+                                        }, 
+                                        "angleitem": {
+                                            "type": "string", 
+                                            "metadata": {
+                                                "maxVersion": 7.6
+                                            }
+                                        }, 
+                                        "pattern": {
+                                            "allOf": [
+                                                {
+                                                    "items": {
+                                                        "items": {
+                                                            "minItems": 2, 
+                                                            "type": "number", 
+                                                            "maxItems": 2
+                                                        }, 
+                                                        "type": "array"
+                                                    }, 
+                                                    "type": "array"
+                                                }
+                                            ], 
+                                            "metadata": {
+                                                "minVersion": 6.0
+                                            }
+                                        }, 
+                                        "outlinecolor": {
+                                            "oneOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "minItems": 3, 
+                                                            "items": {
+                                                                "minimum": -1, 
+                                                                "type": "number", 
+                                                                "maximum": 255
+                                                            }, 
+                                                            "type": "array", 
+                                                            "maxItems": 3
+                                                        }, 
+                                                        {
+                                                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                            "type": "string", 
+                                                            "example": "#aa33cc"
+                                                        }
+                                                    ]
+                                                }, 
+                                                {
+                                                    "pattern": "^\\[(.*?)\\]$", 
+                                                    "type": "string", 
+                                                    "description": "attribute", 
+                                                    "metadata": {
+                                                        "minVersion": 5.0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }, 
+                                "type": "array"
+                            }, 
+                            "buffer": {
+                                "type": "integer"
+                            }, 
+                            "antialias": {
+                                "type": "boolean"
+                            }, 
+                            "backgroundshadowsize": {
+                                "allOf": [
+                                    {
+                                        "items": {
+                                            "items": {
+                                                "minItems": 2, 
+                                                "type": "number", 
+                                                "maxItems": 2
+                                            }, 
+                                            "type": "array"
+                                        }, 
+                                        "type": "array"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.0
+                                }
+                            }, 
+                            "shadowcolor": {
+                                "oneOf": [
+                                    {
+                                        "minItems": 3, 
+                                        "items": {
+                                            "minimum": -1, 
+                                            "type": "number", 
+                                            "maximum": 255
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 3
+                                    }, 
+                                    {
+                                        "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                        "type": "string", 
+                                        "example": "#aa33cc"
+                                    }
+                                ]
+                            }, 
+                            "backgroundcolor": {
+                                "allOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "maxVersion": 6.0
+                                }
+                            }, 
+                            "offset": {
+                                "default": [
+                                    0, 
+                                    0
+                                ], 
+                                "oneOf": [
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "type": "number"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2
+                                    }, 
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "pattern": "^\\[(.*?)\\]$", 
+                                            "type": "string", 
+                                            "description": "attribute"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2, 
+                                        "metadata": {
+                                            "minVersion": 7.6
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "backgroundshadowcolor": {
+                                "allOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "minItems": 3, 
+                                                "items": {
+                                                    "minimum": -1, 
+                                                    "type": "number", 
+                                                    "maximum": 255
+                                                }, 
+                                                "type": "array", 
+                                                "maxItems": 3
+                                            }, 
+                                            {
+                                                "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                                                "type": "string", 
+                                                "example": "#aa33cc"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "maxVersion": 6.0
+                                }
+                            }, 
+                            "minfeaturesize": {
+                                "oneOf": [
+                                    {
+                                        "enum": [
+                                            "auto"
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "integer"
+                                    }
+                                ]
+                            }, 
+                            "maxoverlapangle": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 6.0
+                                }
+                            }, 
+                            "shadowsize": {
+                                "default": [
+                                    1, 
+                                    1
+                                ], 
+                                "oneOf": [
+                                    {
+                                        "minItems": 2, 
+                                        "items": {
+                                            "type": "integer"
+                                        }, 
+                                        "type": "array", 
+                                        "maxItems": 2
+                                    }, 
+                                    {
+                                        "minItems": 2, 
+                                        "items": [
+                                            {
+                                                "type": "integer"
+                                            }, 
+                                            {
+                                                "pattern": "^\\[(.*?)\\]$", 
+                                                "type": "string", 
+                                                "description": "attribute"
+                                            }
+                                        ], 
+                                        "type": "array", 
+                                        "maxItems": 2, 
+                                        "metadata": {
+                                            "minVersion": 6.0
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "align": {
+                                "oneOf": [
+                                    {
+                                        "additionalProperties": false, 
+                                        "enum": [
+                                            "left", 
+                                            "center", 
+                                            "right"
+                                        ], 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "maxscaledenom": {
+                                "type": "number", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "maxlength": {
+                                "type": "integer", 
+                                "metadata": {
+                                    "minVersion": 5.4
+                                }
+                            }, 
+                            "position": {
+                                "default": "cc", 
+                                "oneOf": [
+                                    {
+                                        "enum": [
+                                            "auto"
+                                        ]
+                                    }, 
+                                    {
+                                        "enum": [
+                                            "ul", 
+                                            "uc", 
+                                            "ur", 
+                                            "cl", 
+                                            "cc", 
+                                            "cr", 
+                                            "ll", 
+                                            "lc", 
+                                            "lr"
+                                        ]
+                                    }, 
+                                    {
+                                        "pattern": "^\\[(.*?)\\]$", 
+                                        "type": "string", 
+                                        "description": "attribute"
+                                    }
+                                ]
+                            }, 
+                            "expression": {
+                                "allOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "pattern": "^\\((.*?)\\)$", 
+                                                "type": "string", 
+                                                "description": "expression"
+                                            }, 
+                                            {
+                                                "pattern": "^/(.*?)/$", 
+                                                "type": "string", 
+                                                "description": "regex"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "metadata": {
+                                    "minVersion": 6.2
+                                }
+                            }
+                        }
+                    }, 
+                    "type": "array", 
+                    "maxItems": 1
+                }, 
+                "__type__": {
+                    "enum": [
+                        "legend"
+                    ]
+                }, 
+                "interlace": {
+                    "allOf": [
+                        {
+                            "enum": [
+                                "on", 
+                                "off"
+                            ], 
+                            "type": "string"
+                        }
+                    ], 
+                    "metadata": {
+                        "maxVersion": 7.6
+                    }
+                }, 
+                "keysize": {
+                    "default": [
+                        20, 
+                        10
+                    ], 
+                    "items": {
+                        "type": "integer"
+                    }, 
+                    "type": "array", 
+                    "minItems": 2, 
+                    "maxItems": 2
+                }, 
+                "template": {
+                    "type": "string", 
+                    "description": "filename"
+                }, 
+                "position": {
+                    "enum": [
+                        "ul", 
+                        "uc", 
+                        "ur", 
+                        "cl", 
+                        "cc", 
+                        "cr", 
+                        "ll", 
+                        "lc", 
+                        "lr"
+                    ]
+                }, 
+                "include": {
+                    "items": {
+                        "type": "string"
+                    }, 
+                    "type": "array"
+                }, 
+                "transparent": {
+                    "allOf": [
+                        {
+                            "enum": [
+                                "on", 
+                                "off"
+                            ], 
+                            "type": "string"
+                        }
+                    ], 
+                    "metadata": {
+                        "maxVersion": 7.6
+                    }
+                }, 
+                "keyspacing": {
+                    "default": [
+                        5, 
+                        5
+                    ], 
+                    "items": {
+                        "type": "integer"
+                    }, 
+                    "type": "array", 
+                    "minItems": 2, 
+                    "maxItems": 2
+                }, 
+                "outlinecolor": {
+                    "oneOf": [
+                        {
+                            "minItems": 3, 
+                            "items": {
+                                "minimum": -1, 
+                                "type": "number", 
+                                "maximum": 255
+                            }, 
+                            "type": "array", 
+                            "maxItems": 3
+                        }, 
+                        {
+                            "pattern": "^#([a-fA-F0-9]{6,8}|[a-fA-F0-9]{3,4})$", 
+                            "type": "string", 
+                            "example": "#aa33cc"
+                        }
+                    ]
+                }
+            }
         }, 
         "imagequality": {
-            "type": "integer"
+            "type": "integer", 
+            "metadata": {
+                "maxVersion": 7.6
+            }
         }, 
         "debug": {
-            "enum": [
-                "on", 
-                "off", 
-                0, 
-                1, 
-                2, 
-                3, 
-                4, 
-                5
-            ]
+            "allOf": [
+                {
+                    "enum": [
+                        "on", 
+                        "off", 
+                        0, 
+                        1, 
+                        2, 
+                        3, 
+                        4, 
+                        5
+                    ]
+                }
+            ], 
+            "metadata": {
+                "minVersion": 5.0
+            }
         }, 
         "resolution": {
-            "type": "integer"
+            "type": "number"
         }, 
         "templatepattern": {
             "type": "string"

--- a/docs/scripts/class_diagrams.py
+++ b/docs/scripts/class_diagrams.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Create MapServer class diagrams
 
 Requires https://graphviz.gitlab.io/_pages/Download/Download_windows.html
@@ -17,13 +17,16 @@ https://graphviz.readthedocs.io/en/stable/examples.html#er-py
 """
 
 import os
-import pprint
-import pydot 
+import pydot
+# import pprint
+
 
 FONT = "Lucida Sans"
 
+
 def graphviz_setup(gviz_path):
     os.environ['PATH'] = gviz_path + ";" + os.environ['PATH']
+
 
 def add_child(graph, child_id, child_label, parent_id, colour):
     """
@@ -33,6 +36,7 @@ def add_child(graph, child_id, child_label, parent_id, colour):
     graph.add_node(node)
     graph.add_edge(pydot.Edge(parent_id, node))
 
+
 def add_children(graph, parent_id, d, level=0):
 
     blue = "#6b6bd1"
@@ -41,11 +45,12 @@ def add_children(graph, parent_id, d, level=0):
     colours = [blue, white, green] * 3
 
     for class_, children in d.items():
-        colour = colours[level]    
+        colour = colours[level]
         child_label = class_
         child_id = parent_id + "_" + class_
         add_child(graph, child_id, child_label, parent_id, colour)
         add_children(graph, child_id, children, level+1)
+
 
 def save_file(graph, fn):
     filename = "%s.png" % fn
@@ -53,37 +58,45 @@ def save_file(graph, fn):
     graph.write("%s.dot" % fn)
     os.startfile(filename)
 
+
 def main(gviz_path, layer_only=False):
 
     graphviz_setup(gviz_path)
     graph = pydot.Dot(graph_type='digraph', rankdir="TB")
-    
-    layer_children = {'CLASS': {'LABEL': {'STYLE': {}},
-               'CONNECTIONOPTIONS': {},
-               'LEADER': {'STYLE': {}},
-               'STYLE': {},
-               'VALIDATION': {}},
-     'CLUSTER': {},
-     'COMPOSITE': {},
-     'FEATURE': {'POINTS': {}},
-     'GRID': {},
-     'JOIN': {},
-     'METADATA': {},
-     'PROJECTION': {},
-     'SCALETOKEN': {'VALUES': {}},
-     'VALIDATION': {}}
-   
-    #pprint.pprint(layer_children)
+
+    layer_children = {
+            'CLASS': {
+                'LABEL': {'STYLE': {}},
+                'CONNECTIONOPTIONS': {},
+                'LEADER': {'STYLE': {}},
+                'STYLE': {},
+                'VALIDATION': {}
+            },
+            'CLUSTER': {},
+            'COMPOSITE': {},
+            'FEATURE': {'POINTS': {}},
+            'GRID': {},
+            'JOIN': {},
+            'METADATA': {},
+            'PROJECTION': {},
+            'SCALETOKEN': {'VALUES': {}},
+            'VALIDATION': {}
+     }
+
+    # pprint.pprint(layer_children)
 
     classes = {
-        "MAP": {"LAYER": layer_children, 
-         'LEGEND': {'LABEL': {}},
-         'PROJECTION': {},
-         'QUERYMAP': {},
-         'REFERENCE': {},
-         'SCALEBAR': {'LABEL': {}},
-         'SYMBOL': {},
-         'WEB': {'METADATA': {}, 'VALIDATION': {}}}}        
+        "MAP": {
+            "LAYER": layer_children,
+            'LEGEND': {'LABEL': {}},
+            'PROJECTION': {},
+            'QUERYMAP': {},
+            'REFERENCE': {},
+            'SCALEBAR': {'LABEL': {}},
+            'SYMBOL': {},
+            'WEB': {'METADATA': {}, 'VALIDATION': {}}
+        }
+     }
 
     if layer_only:
         root = "LAYER"
@@ -97,6 +110,7 @@ def main(gviz_path, layer_only=False):
     graph.add_node(node)
     add_children(graph, root, classes[root])
     save_file(graph, fn)
+
 
 if __name__ == "__main__":
     gviz_path = r"C:\Program Files (x86)\Graphviz2.38\bin"

--- a/docs/scripts/create_diagram.py
+++ b/docs/scripts/create_diagram.py
@@ -3,8 +3,10 @@ import os
 
 GVIZ_PATH = r"C:\Program Files (x86)\Graphviz2.38\bin"
 
+
 def graphviz_setup():
     os.environ['PATH'] = GVIZ_PATH + ';' + os.environ['PATH']
+
 
 def create_layer_diagram():
     s = """
@@ -23,6 +25,7 @@ def create_layer_diagram():
     of = './docs/images/class_parsed.png'
 
     ast.to_png_with_pydot(of)
+
 
 if __name__ == "__main__":
     create_layer_diagram()

--- a/docs/scripts/make_json_schema.py
+++ b/docs/scripts/make_json_schema.py
@@ -1,4 +1,4 @@
-"""
+r"""
 jsonref
 
 Docs
@@ -10,53 +10,46 @@ jsonschema2rst %input_folder% %output_folder%
 
 """
 import os
-from pprint import pprint
-import jsonref
-from jsonref import JsonRef
+import json
+from jsonschema import Draft4Validator
+import glob
+from mappyfile.validator import Validator
 
-def get_full_schema(schema_dir):
-    print(schema_dir)
-    os.chdir(schema_dir)
-    fn = "map.json"
 
-    uri = "file:///{}/".format(schema_dir)
+def check_schema(fn):
+
+    print(fn)
 
     with open(fn) as f:
-        j = jsonref.load(f, base_uri=uri)
+        jsn = json.load(f)
+        Draft4Validator.check_schema(jsn)
 
-    jsn = jsonref.dumps(j, indent=4, sort_keys=False)
-    full_schema = jsonref.dumps(j, indent=4, sort_keys=False)
-    with open(r"C:\Temp\mapfile.json", "w") as f:
+
+def save_full_schema(output_file):
+
+    validator = Validator()
+
+    # check individual schema files
+
+    fld = validator.get_schemas_folder()
+    jsn_files = glob.glob(fld + '/*.json')
+
+    for fn in jsn_files:
+        check_schema(fn)
+
+    # now check the combined schema
+    jsn = validator.get_versioned_schema()
+    full_schema = json.dumps(jsn, indent=4, sort_keys=False)
+
+    with open(output_file, "w") as f:
         f.write(full_schema)
 
-    return full_schema
+    check_schema(output_file)
 
-# create_versioned_schema
-
-def update_schema(full_schema):
-    if isinstance(obj, dict):
-        for k in obj.keys():
-            if k == bad:
-                del obj[k]
-            else:
-                update_schema(obj[k], bad)
-    elif isinstance(obj, list):
-        for i in reversed(range(len(obj))):
-            if obj[i] == bad:
-                del obj[i]
-            else:
-                update_schema(obj[i], bad)
-
-    else:
-        # neither a dict nor a list, do nothing
-        pass
-
-def main(schema_dir):
-    full_schema = get_full_schema(schema_dir)
-    update_schema(full_schema)
 
 if __name__ == "__main__":
-    project_dir = os.path.dirname(os.path.dirname(__file__))
-    schema_dir = os.path.join(project_dir, "mappyfile", "schemas")
-    main(schema_dir)
+    project_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    output_file = os.path.join(project_dir, "docs", "schemas", "mapfile.json")
+    print(output_file)
+    save_full_schema(output_file)
     print("Done!")

--- a/docs/scripts/xsdschema.py
+++ b/docs/scripts/xsdschema.py
@@ -1,9 +1,7 @@
-"""
+r"""
 Use forked version to get lxml as a wheel
 pip install git+https://github.com/geographika/xsdtojson.git
 """
-import xsdtojson
-
 from xsdtojson import xsd_to_json_schema
 
 xsd_file = r"D:\GitHub\mapserver\xmlmapfile\mapfile.xsd"

--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -12,7 +12,7 @@
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
     <InterpreterId>MSBuild|mappyfile|$(MSBuildProjectFullPath)</InterpreterId>
-    <StartupFile>tests\test_map_collection.py</StartupFile>
+    <StartupFile>tests\test_utils.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>PATH=C:\MapServer\bin;%PATH%
@@ -197,6 +197,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     </Content>
     <Content Include="mappyfile\schemas\connectionoptions.json" />
     <Content Include="mappyfile\schemas\points.json" />
+    <Content Include="mappyfile\schemas\symbolset.json" />
     <Content Include="mappyfile\schemas\web.json" />
     <Content Include="mappyfile\schemas\validation.json" />
     <Content Include="mappyfile\schemas\metadata.json" />

--- a/mappyfile/__init__.py
+++ b/mappyfile/__init__.py
@@ -33,12 +33,12 @@ import sys
 from types import ModuleType
 # allow high-level functions to be accessed directly from the mappyfile module
 from mappyfile.utils import open, load, loads, find, findall, findunique, dumps, dump, save
-from mappyfile.utils import findkey, update, validate
+from mappyfile.utils import findkey, update, validate, create
 
 __version__ = "0.9.2"
 
 __all__ = ['open', 'load', 'loads', 'find', 'findall', 'findunique', 'dumps', 'dump', 'save',
-           'findkey', 'update', 'validate']
+           'findkey', 'update', 'validate', 'create']
 
 
 plugins = ModuleType('mappyfile.plugins')

--- a/mappyfile/schemas/label.json
+++ b/mappyfile/schemas/label.json
@@ -32,6 +32,7 @@
       }
     },
     "angle": {
+      "default":  0,
       "oneOf": [
         {
           "type": "string",
@@ -52,7 +53,8 @@
       ]
     },
     "antialias": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "backgroundcolor": {
       "allOf": [
@@ -75,17 +77,19 @@
       }
     },
     "backgroundshadowsize": {
+      "default": false,
       "allOf": [
         {
           "$ref": "points.json"
         }
       ],
       "metadata": {
-        "minVersion": 6.0
+        "maxVersion": 6.0
       }
     },
     "buffer": {
-      "type": "integer"
+      "type": "integer",
+      "deafult":  0
     },
     "color": {
       "oneOf": [
@@ -132,6 +136,7 @@
       ]
     },
     "force": {
+      "default": false,
       "oneOf": [
         {
           "type": "boolean"
@@ -151,6 +156,7 @@
       }
     },
     "maxoverlapangle": {
+      "default":  22.5,
       "type": "number",
       "metadata": {
         "minVersion": 6.0
@@ -163,7 +169,8 @@
       }
     },
     "maxsize": {
-      "type": "integer"
+      "type": "integer",
+      "default": 256
     },
     "mindistance": {
       "type": "integer"
@@ -183,9 +190,11 @@
       }
     },
     "minsize": {
-      "type": "integer"
+      "type": "integer",
+      "default": 4
     },
     "offset": {
+      "default": [ 0, 0 ],
       "oneOf": [
         {
           "type": "array",
@@ -224,12 +233,15 @@
       ]
     },
     "outlinewidth": {
-      "type": "integer"
+      "type": "integer",
+      "default": 1
     },
     "partials": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "position": {
+      "default":  "cc",
       "oneOf": [
         { "enum": [ "auto" ] },
         {
@@ -243,6 +255,7 @@
       ]
     },
     "priority": {
+      "default": 1,
       "oneOf": [
         {
           "type": "integer"
@@ -268,6 +281,7 @@
       "$ref": "color.json"
     },
     "shadowsize": {
+      "default": [ 1, 1 ],
       "oneOf": [
         {
           "type": "array",
@@ -298,6 +312,7 @@
       ]
     },
     "size": {
+      "default": 10,
       "anyOf": [
         {
           "type": "integer"

--- a/mappyfile/schemas/layer.json
+++ b/mappyfile/schemas/layer.json
@@ -4,6 +4,7 @@
   "patternProperties": {
     "^__[a-z]+__$": {}
   },
+  "required": [ "type" ],
   "properties": {
     "__type__": {
       "enum": [ "layer" ]
@@ -285,6 +286,7 @@
       "enum": [ "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "pixels" ]
     },
     "status": {
+      "default": "off",
       "type": "string",
       "enum": [ "on", "off", "default" ]
     },
@@ -301,6 +303,7 @@
       "type": "string"
     },
     "tileitem": {
+      "default": "location",
       "type": "string"
     },
     "tilesrs": {
@@ -339,6 +342,7 @@
       "enum": [ "chart", "circle", "line", "point", "polygon", "raster", "query", "annotation" ]
     },
     "units": {
+      "default": "meters",
       "enum": [ "dd", "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "percentages", "pixels" ]
     },
     "utfdata": {

--- a/mappyfile/schemas/legend.json
+++ b/mappyfile/schemas/legend.json
@@ -28,6 +28,7 @@
       }
     },
     "keysize": {
+      "default": [ 20, 10 ],
       "type": "array",
       "items": {
         "type": "integer"
@@ -36,7 +37,7 @@
       "maxItems": 2
     },
     "keyspacing": {
-
+      "default": [ 5, 5 ],
       "type": "array",
       "items": {
         "type": "integer"
@@ -62,6 +63,7 @@
       "type": "boolean"
     },
     "status": {
+      "default": "off",
       "type": "string",
       "enum": [ "on", "off", "embed" ]
     },

--- a/mappyfile/schemas/map.json
+++ b/mappyfile/schemas/map.json
@@ -16,7 +16,8 @@
       }
     },
     "angle": {
-      "type": "number"
+      "type": "number",
+      "default": 0
     },
     "config": {
       "type": "object",
@@ -29,6 +30,7 @@
         },
         "ON_MISSING_DATA": {
           "type": "string",
+          "default": "FAIL",
           "enum": [ "FAIL", "LOG", "IGNORE" ]
         },
         "PROJ_LIB": { "type": "string" }
@@ -39,6 +41,7 @@
       "type": "string"
     },
     "debug": {
+      "default": 0,
       "allOf": [
         {
           "$ref": "debug.json"
@@ -50,6 +53,7 @@
     },
     "defresolution": {
       "type": "number",
+      "default": 72,
       "metadata": {
         "minVersion": 5.6
       }
@@ -70,6 +74,7 @@
       }
     },
     "imagetype": {
+      "default": "png",
       "type": "string"
     },
     "interlace": {
@@ -93,9 +98,11 @@
       "$ref": "legend.json"
     },
     "maxsize": {
+      "default": 4096,
       "type": "integer"
     },
     "name": {
+      "default": "MS",
       "type": "string"
     },
     "outputformats": {
@@ -115,6 +122,7 @@
       "$ref": "reference.json"
     },
     "resolution": {
+      "default": 72,
       "type": "number"
     },
     "scaledenom": {
@@ -127,6 +135,7 @@
       "type": "string"
     },
     "size": {
+      "default": [ -1, -1 ],
       "type": "array",
       "items": {
         "type": "integer"
@@ -135,6 +144,7 @@
       "maxItems": 2
     },
     "status": {
+      "default": "on",
       "$ref": "onoff.json"
     },
     "symbolset": {
@@ -161,6 +171,7 @@
       }
     },
     "units": {
+      "default": "meters",
       "$ref": "units.json"
     },
     "web": {

--- a/mappyfile/schemas/querymap.json
+++ b/mappyfile/schemas/querymap.json
@@ -18,6 +18,7 @@
       "$ref": "color.json"
     },
     "size": {
+      "default": [ -1, -1 ],
       "type": "array",
       "items": {
         "type": "integer"
@@ -26,9 +27,11 @@
       "maxItems": 2
     },
     "status": {
+      "default": "off",
       "$ref": "onoff.json"
     },
     "style": {
+      "default": "hilite",
       "type": "string",
       "enum": [ "normal", "hilite", "selected" ],
       "additionalProperties": false

--- a/mappyfile/schemas/scalebar.json
+++ b/mappyfile/schemas/scalebar.json
@@ -38,6 +38,7 @@
       }
     },
     "intervals": {
+      "default": 4,
       "type": "integer"
     },
     "labels": {
@@ -58,6 +59,7 @@
       "type": "boolean"
     },
     "size": {
+      "default": [ 200, 3 ],
       "type": "array",
       "items": {
         "type": "integer"
@@ -66,6 +68,7 @@
       "maxItems": 2
     },
     "status": {
+      "deafult": "off",
       "type": "string",
       "enum": [ "on", "off", "embed" ]
     },
@@ -80,6 +83,7 @@
       ]
     },
     "units": {
+      "default": "miles",
       "$ref": "sizeunits.json"
     },
     "extent": {

--- a/mappyfile/schemas/symbol.json
+++ b/mappyfile/schemas/symbol.json
@@ -16,6 +16,7 @@
     },
     "anchorpoint": {
       "type": "array",
+      "default": [ 0.5, 0.5 ],
       "items": [
         {
           "type": "number",
@@ -31,6 +32,7 @@
     },
     "antialias": {
       "type": "boolean",
+      "default": false,
       "metadata": {
         "maxVersion": 7.6
       }
@@ -53,7 +55,8 @@
       ]
     },
     "filled": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "font": {
       "type": "string"

--- a/mappyfile/schemas/symbolset.json
+++ b/mappyfile/schemas/symbolset.json
@@ -1,9 +1,17 @@
 {
+  "$schema": "http://json-schema.org/schema#",
   "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^__[a-z]+__$": {}
+  },
   "properties": {
-    "type": "array",
-    "items": {
-      "$ref": "symbol.json"
+    "symbols": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "symbol.json"
+      }
     }
   }
 }

--- a/mappyfile/schemas/web.json
+++ b/mappyfile/schemas/web.json
@@ -98,7 +98,7 @@
       "type": "string"
     },
     "temppath": {
-      "type": "url",
+      "type": "string",
       "description": "path",
       "metadata": {
         "minVersion": 6.0

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -656,7 +656,7 @@ def create(type, version=None):
     d = OrderedDict()
     d["__type__"] = type
 
-    properties = schema["properties"].items()
+    properties = sorted(schema["properties"].items())
 
     for k, v in properties:
         if "default" in v:

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -625,3 +625,39 @@ def _pprint(d, indent, spacer, quote, newlinechar, end_comment, **kwargs):
                        quote=quote, newlinechar=newlinechar,
                        end_comment=end_comment, **kwargs)
     return pp.pprint(d)
+
+
+def create(type, version=None):
+    """
+    Create a new mappyfile object, using MapServer defaults (if any).
+
+    Parameters
+    ----------
+
+    s: type
+        The mappyfile type to be stored in the __type__ property
+
+    Returns
+    -------
+
+    dict
+        A Python dictionary representing the Mapfile object in the mappyfile format
+    """
+
+    # get the schema for this type
+
+    v = Validator()
+    try:
+        schema = v.get_versioned_schema(version=version, schema_name=type)
+    except IOError:
+        raise SyntaxError("The mappyfile type '{}' does not exist!".format(type))
+
+    d = {"__type__": type}
+
+    properties = schema["properties"].items()
+
+    for k, v in properties:
+        if "default" in v:
+            d[k] = v["default"]
+
+    return d

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -31,6 +31,7 @@ from __future__ import unicode_literals
 import codecs
 import warnings
 import functools
+from collections import OrderedDict
 from mappyfile.parser import Parser
 from mappyfile.transformer import MapfileToDict
 from mappyfile.pprint import PrettyPrinter
@@ -652,7 +653,8 @@ def create(type, version=None):
     except IOError:
         raise SyntaxError("The mappyfile type '{}' does not exist!".format(type))
 
-    d = {"__type__": type}
+    d = OrderedDict()
+    d["__type__"] = type
 
     properties = schema["properties"].items()
 

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -2,7 +2,7 @@
 #
 # Authors: Seth Girvin
 #
-# Copyright (c) 2020 Seth Girvin
+# Copyright (c) 2021 Seth Girvin
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -916,13 +916,14 @@ def test_multiple_layer_data():
 
     s = u"""
     LAYER
+        TYPE POINT
         DATA "dataset1"
         DATA "dataset2"
     END
     """
 
     print(output(s, schema_name="layer"))
-    exp = u"LAYER DATA 'dataset1' DATA 'dataset2' END"
+    exp = u"LAYER TYPE POINT DATA 'dataset1' DATA 'dataset2' END"
     assert(output(s, schema_name="layer") == exp)
 
 
@@ -930,6 +931,7 @@ def test_single_layer_data():
 
     s = u"""
     LAYER
+        TYPE POINT
         DATA "dataset1"
     END
     """
@@ -939,7 +941,7 @@ def test_single_layer_data():
     print(mappyfile.dumps(jsn))
 
     print(output(s, schema_name="layer"))
-    exp = u"LAYER DATA 'dataset1' END"
+    exp = u"LAYER TYPE POINT DATA 'dataset1' END"
     assert(output(s, schema_name="layer") == exp)
 
 
@@ -947,6 +949,7 @@ def test_cluster():
 
     s = u"""
     LAYER
+        TYPE POINT
         CLUSTER
             MAXDISTANCE 50
             REGION "ELLIPSE"
@@ -954,7 +957,7 @@ def test_cluster():
     END
     """
     print(output(s, schema_name="layer"))
-    exp = u"LAYER CLUSTER MAXDISTANCE 50 REGION 'ELLIPSE' END END"
+    exp = u"LAYER TYPE POINT CLUSTER MAXDISTANCE 50 REGION 'ELLIPSE' END END"
     assert(output(s, schema_name="layer") == exp)
 
 
@@ -966,6 +969,7 @@ def test_cluster2():
     """
     s = u"""
     LAYER
+        TYPE POINT
         CLUSTER
             MAXDISTANCE 50
             REGION ELLIPSE
@@ -973,7 +977,7 @@ def test_cluster2():
     END
     """
     print(output(s, schema_name="layer"))
-    exp = u"LAYER CLUSTER MAXDISTANCE 50 REGION 'ELLIPSE' END END"
+    exp = u"LAYER TYPE POINT CLUSTER MAXDISTANCE 50 REGION 'ELLIPSE' END END"
     assert(output(s, schema_name="layer") == exp)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -330,7 +330,8 @@ def test_create_label():
     d = mappyfile.utils.create("label")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     print(output)
-    assert output == "LABEL SHADOWSIZE 1 1 REPEATDISTANCE 0 OFFSET 0 0 POSITION CC SIZE 10 END"
+    assert output == "LABEL PRIORITY 1 MAXOVERLAPANGLE 22.5 FORCE FALSE SHADOWSIZE 1 1 POSITION CC MAXSIZE 256 ANTIALIAS FALSE "\
+                     "MINSIZE 4 PARTIALS FALSE REPEATDISTANCE 0 OFFSET 0 0 ANGLE 0 OUTLINEWIDTH 1 BACKGROUNDSHADOWSIZE FALSE SIZE 10 END"
 
 
 def test_create_symbol():
@@ -373,5 +374,5 @@ def run_tests():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
-    test_create_symbol_v6()
+    test_create_label()
     print("Done!")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -374,6 +374,6 @@ def run_tests():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    # run_tests()
-    test_create_layer()
+    run_tests()
+    # test_create_layer()
     print("Done!")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,12 +313,65 @@ def test_findunique():
     assert groups == ["group1", "group2"]
 
 
+def test_create_map():
+    d = mappyfile.utils.create("map")
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    print(output)
+    assert output == "MAP ANGLE 0 NAME 'MS' DEFRESOLUTION 72 MAXSIZE 4096 DEBUG 0 RESOLUTION 72 IMAGETYPE 'png' SIZE -1 -1 END"
+
+
+def test_create_layer():
+    d = mappyfile.utils.create("layer")
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    assert output == "LAYER UNITS METERS STATUS OFF TILEITEM 'location' END"
+
+
+def test_create_label():
+    d = mappyfile.utils.create("label")
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    print(output)
+    assert output == "LABEL SHADOWSIZE 1 1 REPEATDISTANCE 0 OFFSET 0 0 POSITION CC SIZE 10 END"
+
+
+def test_create_symbol():
+    d = mappyfile.utils.create("symbol")
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    print(output)
+    assert output == "SYMBOL ANCHORPOINT 0.5 0.5 ANTIALIAS FALSE FILLED FALSE END"
+
+
+def test_create_symbol_v6():
+    d = mappyfile.utils.create("symbol", version=6.0)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    print(output)
+    assert output == "SYMBOL ANTIALIAS FALSE FILLED FALSE END"
+
+
+def test_create_symbol_v8():
+    d = mappyfile.utils.create("symbol", version=8.0)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    print(output)
+    assert output == "SYMBOL ANCHORPOINT 0.5 0.5 FILLED FALSE END"
+
+
+def test_create_missing():
+
+    error_raised = False
+    try:
+        mappyfile.utils.create("missing")
+    except SyntaxError:
+        # raise
+        error_raised = True
+
+    assert error_raised is True
+
+
 def run_tests():
     pytest.main(["tests/test_utils.py"])
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    run_tests()
-    # test_dumps()
+    # run_tests()
+    test_create_symbol_v6()
     print("Done!")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -317,21 +317,22 @@ def test_create_map():
     d = mappyfile.utils.create("map")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     print(output)
-    assert output == "MAP ANGLE 0 NAME 'MS' DEFRESOLUTION 72 MAXSIZE 4096 DEBUG 0 RESOLUTION 72 IMAGETYPE 'png' SIZE -1 -1 END"
+    assert output == "MAP ANGLE 0 DEBUG 0 DEFRESOLUTION 72 IMAGETYPE 'png' MAXSIZE 4096 NAME 'MS' RESOLUTION 72 SIZE -1 -1 END"
 
 
 def test_create_layer():
     d = mappyfile.utils.create("layer")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    assert output == "LAYER UNITS METERS STATUS OFF TILEITEM 'location' END"
+    print(output)
+    assert output == "LAYER STATUS OFF TILEITEM 'location' UNITS METERS END"
 
 
 def test_create_label():
     d = mappyfile.utils.create("label")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     print(output)
-    assert output == "LABEL PRIORITY 1 MAXOVERLAPANGLE 22.5 FORCE FALSE SHADOWSIZE 1 1 POSITION CC MAXSIZE 256 ANTIALIAS FALSE "\
-                     "MINSIZE 4 PARTIALS FALSE REPEATDISTANCE 0 OFFSET 0 0 ANGLE 0 OUTLINEWIDTH 1 BACKGROUNDSHADOWSIZE FALSE SIZE 10 END"
+    assert output == "LABEL ANGLE 0 ANTIALIAS FALSE BACKGROUNDSHADOWSIZE FALSE FORCE FALSE MAXOVERLAPANGLE 22.5 MAXSIZE 256 MINSIZE 4 "\
+                     "OFFSET 0 0 OUTLINEWIDTH 1 PARTIALS FALSE POSITION CC PRIORITY 1 REPEATDISTANCE 0 SHADOWSIZE 1 1 SIZE 10 END"
 
 
 def test_create_symbol():
@@ -374,5 +375,5 @@ def run_tests():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
-    test_create_label()
+    test_create_layer()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -196,6 +196,7 @@ def test_hexcolor_validation_translucence():
     s = """
     MAP
         LAYER
+            TYPE POINT
             CLASS
                 STYLE
                     COLOR '#FF00FFCC'
@@ -476,6 +477,7 @@ def test_cluster_validation():
     s = u"""
     MAP
         LAYER
+            TYPE POINT
             CLUSTER
                 MAXDISTANCE 50
                 REGION "ELLIPSE"
@@ -497,6 +499,7 @@ def test_cluster_validation_fail():
     s = u"""
     MAP
         LAYER
+            TYPE POINT
             CLUSTER
                 MAXDISTANCE 50
                 REGION "ELLIPSEZ"


### PR DESCRIPTION
Adds a new `create` function that allows Mapfile objects to be created with their default values:

```python
>>> import json
>>> import mappyfile
>>> m = mappyfile.create("map", version=8.0)
>>> print(mappyfile.dumps(m))
MAP
    ANGLE 0
    NAME "MS"
    DEFRESOLUTION 72
    MAXSIZE 4096
    DEBUG 0
    RESOLUTION 72
    IMAGETYPE "png"
    SIZE -1 -1
END
```

Updates schema objects to have default values for keywords based on MapServer output and Mapfile docs. 