### PR TITLE
New feature: group complex types at the end

### DIFF
--- a/mappyfile/__init__.py
+++ b/mappyfile/__init__.py
@@ -33,12 +33,12 @@ import sys
 from types import ModuleType
 # allow high-level functions to be accessed directly from the mappyfile module
 from mappyfile.utils import open, load, loads, find, findall, findunique, dumps, dump, save
-from mappyfile.utils import findkey, update, validate, create
+from mappyfile.utils import findkey, update, validate, create, dict_move_to_end
 
 __version__ = "0.9.4"
 
 __all__ = ['open', 'load', 'loads', 'find', 'findall', 'findunique', 'dumps', 'dump', 'save',
-           'findkey', 'update', 'validate', 'create']
+           'findkey', 'update', 'validate', 'create', 'dict_move_to_end']
 
 
 plugins = ModuleType('mappyfile.plugins')

--- a/mappyfile/ordereddict.py
+++ b/mappyfile/ordereddict.py
@@ -173,3 +173,6 @@ class CaseInsensitiveOrderedDict(DefaultOrderedDict):
         for k in list(self.keys()):
             v = super(CaseInsensitiveOrderedDict, self).pop(k)
             self.__setitem__(k, v)
+
+    def move_to_end(self, key, last=True):
+        super(CaseInsensitiveOrderedDict, self).move_to_end(self.__class__._k(key), last)

--- a/mappyfile/ordereddict.py
+++ b/mappyfile/ordereddict.py
@@ -173,6 +173,3 @@ class CaseInsensitiveOrderedDict(DefaultOrderedDict):
         for k in list(self.keys()):
             v = super(CaseInsensitiveOrderedDict, self).pop(k)
             self.__setitem__(k, v)
-
-    def move_to_end(self, key, last=True):
-        super(CaseInsensitiveOrderedDict, self).move_to_end(self.__class__._k(key), last)

--- a/mappyfile/ordereddict.py
+++ b/mappyfile/ordereddict.py
@@ -101,32 +101,6 @@ class DefaultOrderedDict(OrderedDict):
         return 'DefaultOrderedDict(%s, %s)' % (self.default_factory,
                                                OrderedDict.__repr__(self))
 
-    # copied from Python 3.10.2 sources to fix missing method in Python 2.7
-    def move_to_end(self, key, last=True):
-        '''Move an existing element to the end (or beginning if last is false).
-
-        Raise KeyError if the element does not exist.
-        '''
-        link = self.__map[key]
-        link_prev = link.prev
-        link_next = link.next
-        soft_link = link_next.prev
-        link_prev.next = link_next
-        link_next.prev = link_prev
-        root = self.__root
-        if last:
-            last = root.prev
-            link.prev = last
-            link.next = root
-            root.prev = soft_link
-            last.next = link
-        else:
-            first = root.next
-            link.prev = root
-            link.next = first
-            first.prev = soft_link
-            root.next = link
-
 
 class CaseInsensitiveOrderedDict(DefaultOrderedDict):
     """

--- a/mappyfile/ordereddict.py
+++ b/mappyfile/ordereddict.py
@@ -101,6 +101,32 @@ class DefaultOrderedDict(OrderedDict):
         return 'DefaultOrderedDict(%s, %s)' % (self.default_factory,
                                                OrderedDict.__repr__(self))
 
+    # copied from Python 3.10.2 sources to fix missing method in Python 2.7
+    def move_to_end(self, key, last=True):
+        '''Move an existing element to the end (or beginning if last is false).
+
+        Raise KeyError if the element does not exist.
+        '''
+        link = self.__map[key]
+        link_prev = link.prev
+        link_next = link.next
+        soft_link = link_next.prev
+        link_prev.next = link_next
+        link_next.prev = link_prev
+        root = self.__root
+        if last:
+            last = root.prev
+            link.prev = last
+            link.next = root
+            root.prev = soft_link
+            last.next = link
+        else:
+            first = root.next
+            link.prev = root
+            link.next = first
+            first.prev = soft_link
+            root.next = link
+
 
 class CaseInsensitiveOrderedDict(DefaultOrderedDict):
     """

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -33,6 +33,7 @@ import logging
 import numbers
 from mappyfile.tokens import COMPOSITE_NAMES, SINGLETON_COMPOSITE_NAMES, REPEATED_KEYS, COMPLEX_TYPES
 from mappyfile.validator import Validator
+import mappyfile as utils
 
 log = logging.getLogger("mappyfile")
 
@@ -192,7 +193,7 @@ class PrettyPrinter(object):
             return
         for key in list(composite.keys()):
             if self.is_complex_type(composite, key, level):
-                composite.move_to_end(key)
+                utils.dict_move_to_end(composite, key)
 
     def whitespace(self, level, indent):
         return self.spacer * (level + indent)

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -31,7 +31,7 @@ from __future__ import unicode_literals
 import sys
 import logging
 import numbers
-from mappyfile.tokens import COMPOSITE_NAMES, SINGLETON_COMPOSITE_NAMES, REPEATED_KEYS
+from mappyfile.tokens import COMPOSITE_NAMES, SINGLETON_COMPOSITE_NAMES, REPEATED_KEYS, COMPLEX_TYPES
 from mappyfile.validator import Validator
 
 log = logging.getLogger("mappyfile")
@@ -130,8 +130,7 @@ class Quoter(object):
 
 
 class PrettyPrinter(object):
-    def __init__(self, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
-                 align_values=False, **kwargs):
+    def __init__(self, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False, align_values=False, separate_complex_types=False, **kwargs):
         """
         Option use "\t" for spacer with an indent of 1
         """
@@ -146,6 +145,7 @@ class PrettyPrinter(object):
         self.end = u"END"
         self.validator = Validator()
         self.align_values = align_values
+        self.separate_complex_types = separate_complex_types
 
     def __is_metadata(self, key):
         """
@@ -186,6 +186,13 @@ class PrettyPrinter(object):
                 length = max(length, attr_length)
 
         return length
+
+    def separate_complex(self, composite):
+        if not self.separate_complex_types:
+            return 
+        for key in list(composite.keys()):
+            if self.is_complex_type(composite, key):
+                composite.move_to_end(key)
 
     def whitespace(self, level, indent):
         return self.spacer * (level + indent)
@@ -331,6 +338,9 @@ class PrettyPrinter(object):
             return True
         else:
             return False
+
+    def is_complex_type(self, composite, key):
+        return key in COMPLEX_TYPES or self.is_composite(key) or self.is_hidden_container(key, composite[key])
 
     def is_hidden_container(self, key, val):
         """
@@ -538,9 +548,11 @@ class PrettyPrinter(object):
             lines.append(s)
 
         aligned_max_indent = 0
-        if (self.align_values):
+        if self.align_values:
             max_key_length = self.compute_max_key_length(composite)
             aligned_max_indent = self.compute_aligned_max_indent(max_key_length)
+
+        self.separate_complex(composite)
 
         for attr, value in composite.items():
             if self.__is_metadata(attr):

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -130,7 +130,8 @@ class Quoter(object):
 
 
 class PrettyPrinter(object):
-    def __init__(self, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False, align_values=False, separate_complex_types=False, **kwargs):
+    def __init__(self, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
+                 align_values=False, separate_complex_types=False, **kwargs):
         """
         Option use "\t" for spacer with an indent of 1
         """
@@ -178,20 +179,19 @@ class PrettyPrinter(object):
         for attr, value in composite.items():
             attr_length = len(attr)
             if (not self.__is_metadata(attr) and
-                    attr not in ("metadata", "validation", "values", "connectionoptions") and
-                    not self.is_hidden_container(attr, value) and not attr == "pattern" and
-                    not attr == "projection" and not attr == "points" and
-                    not attr == "config" and
-                    not self.is_composite(value)):
+                attr not in ("metadata", "validation", "values", "connectionoptions") and
+                not self.is_hidden_container(attr, value) and not attr == "pattern" and
+                not attr == "projection" and not attr == "points" and
+                    not attr == "config" and not self.is_composite(value)):
                 length = max(length, attr_length)
 
         return length
 
-    def separate_complex(self, composite):
+    def separate_complex(self, composite, level):
         if not self.separate_complex_types:
-            return 
+            return
         for key in list(composite.keys()):
-            if self.is_complex_type(composite, key):
+            if self.is_complex_type(composite, key, level):
                 composite.move_to_end(key)
 
     def whitespace(self, level, indent):
@@ -339,7 +339,10 @@ class PrettyPrinter(object):
         else:
             return False
 
-    def is_complex_type(self, composite, key):
+    def is_complex_type(self, composite, key, level):
+        # symbol needs special treatment
+        if key == "symbol" and level > 0:
+            return False
         return key in COMPLEX_TYPES or self.is_composite(key) or self.is_hidden_container(key, composite[key])
 
     def is_hidden_container(self, key, val):
@@ -552,7 +555,7 @@ class PrettyPrinter(object):
             max_key_length = self.compute_max_key_length(composite)
             aligned_max_indent = self.compute_aligned_max_indent(max_key_length)
 
-        self.separate_complex(composite)
+        self.separate_complex(composite, level)
 
         for attr, value in composite.items():
             if self.__is_metadata(attr):

--- a/mappyfile/tokens.py
+++ b/mappyfile/tokens.py
@@ -55,8 +55,8 @@ COMPLEX_TYPES = frozenset("""
     style
     web
     layer
+    symbol
     """.split())
-    #symbol # is only relevant in first level and covered by hidden_container
 
 COMPOSITE_NAMES = frozenset("""
     align

--- a/mappyfile/tokens.py
+++ b/mappyfile/tokens.py
@@ -27,6 +27,37 @@
 #
 # =================================================================
 
+# Types, that require an "END"
+COMPLEX_TYPES = frozenset("""
+    symbolset
+    projection
+    points
+    pattern
+    values
+    metadata
+    validation
+    connectionoptions
+    class
+    cluster
+    composite
+    feature
+    grid
+    join
+    label
+    leader
+    legend
+    map
+    outputformat
+    querymap
+    reference
+    scalebar
+    scaletoken
+    style
+    web
+    layer
+    """.split())
+    #symbol # is only relevant in first level and covered by hidden_container
+
 COMPOSITE_NAMES = frozenset("""
     align
     anchorpoint

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -236,8 +236,7 @@ def dump(d, fp, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=F
     fp.write(map_string)
 
 
-def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
-         align_values=False, **kwargs):
+def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False, align_values=False, separate_complex_types=False, **kwargs):
     """
     Write a dictionary to an output Mapfile on disk
 
@@ -261,8 +260,12 @@ def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_
         Add a comment with the block type at each closing END
         statement e.g. END # MAP
     align_values: bool
-        Aligns the values in the same column for better readability. The column is
-        multiple of indent and determined by the longest key
+        Aligns the values in the same column for better readability. The column is 
+        multiple of indent and determined by the longest key.
+    separate_complex_types: bool
+        Groups composites (complex mapserver definitions with "END") together at the end.
+        Keeps the given order except that all simple key-value pairs appear before composites.
+
     Returns
     -------
 
@@ -280,7 +283,7 @@ def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_
         fn = "C:/Data/mymap.map"
         mappyfile.save(d, fn)
     """
-    map_string = _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values)
+    map_string = _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, separate_complex_types)
     _save(output_file, map_string)
     return output_file
 
@@ -632,10 +635,11 @@ def _save(output_file, string):
         f.write(string)
 
 
-def _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, **kwargs):
+def _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, separate_complex_types, **kwargs):
     pp = PrettyPrinter(indent=indent, spacer=spacer,
                        quote=quote, newlinechar=newlinechar,
-                       end_comment=end_comment, align_values=align_values, **kwargs)
+                       end_comment=end_comment, align_values=align_values, 
+                       separate_complex_types=separate_complex_types, **kwargs)
     return pp.pprint(d)
 
 

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -192,7 +192,7 @@ def loads(s, expand_includes=True, include_position=False, include_comments=Fals
 
 
 def dump(d, fp, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
-         align_values=False):
+         align_values=False, separate_complex_types=False):
     """
     Write d (the Mapfile dictionary) as a formatted stream to fp
 
@@ -218,6 +218,9 @@ def dump(d, fp, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=F
     align_values: bool
         Aligns the values in the same column for better readability. The column is
         multiple of indent and determined by the longest key
+    separate_complex_types: bool
+        Groups composites (complex mapserver definitions with "END") together at the end.
+        Keeps the given order except that all simple key-value pairs appear before composites.
 
     Example
     -------
@@ -232,7 +235,7 @@ def dump(d, fp, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=F
             mappyfile.dump(d, f, indent=2, quote="'")
 
     """
-    map_string = _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values)
+    map_string = _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, separate_complex_types)
     fp.write(map_string)
 
 
@@ -290,7 +293,7 @@ def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_
 
 
 def dumps(d, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
-          align_values=False, **kwargs):
+          align_values=False, separate_complex_types=False, **kwargs):
     """
     Output a Mapfile dictionary as a string
 
@@ -314,6 +317,9 @@ def dumps(d, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=Fals
     align_values: bool
         Aligns the values in the same column for better readability. The column is
         multiple of indent and determined by the longest key
+    separate_complex_types: bool
+        Groups composites (complex mapserver definitions with "END") together at the end.
+        Keeps the given order except that all simple key-value pairs appear before composites.
 
     Returns
     -------
@@ -332,7 +338,7 @@ def dumps(d, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=Fals
         d = mappyfile.loads(s)
         print(mappyfile.dumps(d, indent=1, spacer="\\t"))
     """
-    return _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, **kwargs)
+    return _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, separate_complex_types, **kwargs)
 
 
 def find(lst, key, value):

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -236,7 +236,8 @@ def dump(d, fp, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=F
     fp.write(map_string)
 
 
-def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False, align_values=False, separate_complex_types=False, **kwargs):
+def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_comment=False,
+         align_values=False, separate_complex_types=False, **kwargs):
     """
     Write a dictionary to an output Mapfile on disk
 
@@ -260,7 +261,7 @@ def save(d, output_file, indent=4, spacer=" ", quote='"', newlinechar="\n", end_
         Add a comment with the block type at each closing END
         statement e.g. END # MAP
     align_values: bool
-        Aligns the values in the same column for better readability. The column is 
+        Aligns the values in the same column for better readability. The column is
         multiple of indent and determined by the longest key.
     separate_complex_types: bool
         Groups composites (complex mapserver definitions with "END") together at the end.
@@ -638,7 +639,7 @@ def _save(output_file, string):
 def _pprint(d, indent, spacer, quote, newlinechar, end_comment, align_values, separate_complex_types, **kwargs):
     pp = PrettyPrinter(indent=indent, spacer=spacer,
                        quote=quote, newlinechar=newlinechar,
-                       end_comment=end_comment, align_values=align_values, 
+                       end_comment=end_comment, align_values=align_values,
                        separate_complex_types=separate_complex_types, **kwargs)
     return pp.pprint(d)
 

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 from __future__ import unicode_literals
+import sys
 import codecs
 import warnings
 import functools
@@ -685,3 +686,15 @@ def create(type, version=None):
             d[k] = v["default"]
 
     return d
+
+
+def dict_move_to_end(ordered_dict, key):
+
+    if sys.version_info[0] < 3:
+        # mappyfile requires Python >= 2.7,
+        # so this should be safe
+        val = ordered_dict[key]
+        del ordered_dict[key]
+        ordered_dict[key] = val
+    else:
+        ordered_dict.move_to_end(key)

--- a/tests/test_pprint.py
+++ b/tests/test_pprint.py
@@ -474,6 +474,32 @@ def test_align_values():
             aligned_indexes.add(line.index(words[1]))
     assert len(aligned_indexes) == 1
 
+def test_separate_complex_types():
+    s = """
+    MAP
+        EXTENT 0 0 100 100
+        shapepath "test/path"
+        LAYER
+            CLASS
+                EXPRESSION "Field"
+                STYLE
+                    SIZE [sizefield]
+                END
+                GROUP 'group1'
+            END
+            CLASSITEM "Test"
+        END
+        DEBUG on
+        NAME Test
+    END
+    """
+    ast = mappyfile.loads(s)
+    pp = PrettyPrinter(indent=4, quote="'", newlinechar="\n", separate_complex_types=True)
+    s = pp.pprint(ast)
+    assert s.index("NAME ") < s.index("LAYER\n")
+    assert s.index("DEBUG ") < s.index("LAYER\n")
+    assert s.index("CLASSITEM ") < s.index("CLASS\n")
+    assert s.index("GROUP") < s.index("STYLE\n")
 
 def run_tests():
     # pytest.main(["tests/test_pprint.py::test_format_list"])

--- a/tests/test_pprint.py
+++ b/tests/test_pprint.py
@@ -474,6 +474,7 @@ def test_align_values():
             aligned_indexes.add(line.index(words[1]))
     assert len(aligned_indexes) == 1
 
+
 def test_separate_complex_types():
     s = """
     MAP
@@ -500,6 +501,7 @@ def test_separate_complex_types():
     assert s.index("DEBUG ") < s.index("LAYER\n")
     assert s.index("CLASSITEM ") < s.index("CLASS\n")
     assert s.index("GROUP") < s.index("STYLE\n")
+
 
 def run_tests():
     # pytest.main(["tests/test_pprint.py::test_format_list"])

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,6 @@ commands=
     pytest --ignore=tests/mapfiles --cov mappyfile --cov-report term-missing  docs/examples/api/ misc/ tests/
     flake8 mappyfile --max-line-length=120
     flake8 --ignore=E501,E121,E122,E123,E126,E127,E128 tests --exclude=*/basemaps/*,*/ms-ogc-workshop/*
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Hello,

got some new feature: groups complex types (those that end with 'END') together at the end and thus shifts the "simple" key-value pairs in front of them. 
Also increases readability and creates a clear separation of simple from complex types in the pretty printed result.

The branch I created for it is based on thorag76_1, the one you already accepted.

Attached please find a sample before and after map to illustrate.
[after.map.txt](https://github.com/geographika/mappyfile/files/8062792/after.map.txt)
[before.map.txt](https://github.com/geographika/mappyfile/files/8062793/before.map.txt)
.