### PR TITLE
Add COMPOSITE validation

### DIFF
--- a/docs/schemas/mapfile-latest.json
+++ b/docs/schemas/mapfile-latest.json
@@ -2789,6 +2789,9 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
+                            "metadata": {
+                                "minVersion": 7.0
+                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },
@@ -2798,8 +2801,40 @@
                                         "composite"
                                     ]
                                 },
-                                "compop": {
+                                "compfilter": {
                                     "type": "string"
+                                },
+                                "compop": {
+                                    "enum": [
+                                        "clear",
+                                        "color-burn",
+                                        "color-dodge",
+                                        "contrast",
+                                        "darken",
+                                        "difference",
+                                        "dst",
+                                        "dst-atop",
+                                        "dst-in",
+                                        "dst-out",
+                                        "dst-over",
+                                        "exclusion",
+                                        "hard-light",
+                                        "invert",
+                                        "invert-rgb",
+                                        "lighten",
+                                        "minus",
+                                        "multiply",
+                                        "overlay",
+                                        "plus",
+                                        "screen",
+                                        "soft-light",
+                                        "src",
+                                        "src-atop",
+                                        "src-in",
+                                        "src-out",
+                                        "src-over",
+                                        "xor"
+                                    ]
                                 },
                                 "include": {
                                     "items": {

--- a/docs/schemas/mapfile-latest.json
+++ b/docs/schemas/mapfile-latest.json
@@ -2789,9 +2789,6 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
-                            "metadata": {
-                                "minVersion": 7.0
-                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },

--- a/docs/schemas/mapfile-schema-7-6.json
+++ b/docs/schemas/mapfile-schema-7-6.json
@@ -2718,6 +2718,9 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
+                            "metadata": {
+                                "minVersion": 7.0
+                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },
@@ -2727,8 +2730,40 @@
                                         "composite"
                                     ]
                                 },
-                                "compop": {
+                                "compfilter": {
                                     "type": "string"
+                                },
+                                "compop": {
+                                    "enum": [
+                                        "clear",
+                                        "color-burn",
+                                        "color-dodge",
+                                        "contrast",
+                                        "darken",
+                                        "difference",
+                                        "dst",
+                                        "dst-atop",
+                                        "dst-in",
+                                        "dst-out",
+                                        "dst-over",
+                                        "exclusion",
+                                        "hard-light",
+                                        "invert",
+                                        "invert-rgb",
+                                        "lighten",
+                                        "minus",
+                                        "multiply",
+                                        "overlay",
+                                        "plus",
+                                        "screen",
+                                        "soft-light",
+                                        "src",
+                                        "src-atop",
+                                        "src-in",
+                                        "src-out",
+                                        "src-over",
+                                        "xor"
+                                    ]
                                 },
                                 "include": {
                                     "items": {

--- a/docs/schemas/mapfile-schema-7-6.json
+++ b/docs/schemas/mapfile-schema-7-6.json
@@ -2718,9 +2718,6 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
-                            "metadata": {
-                                "minVersion": 7.0
-                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },

--- a/docs/schemas/mapfile-schema-8-0.json
+++ b/docs/schemas/mapfile-schema-8-0.json
@@ -2288,9 +2288,6 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
-                            "metadata": {
-                                "minVersion": 7.0
-                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },

--- a/docs/schemas/mapfile-schema-8-0.json
+++ b/docs/schemas/mapfile-schema-8-0.json
@@ -2288,6 +2288,9 @@
                     "composites": {
                         "items": {
                             "additionalProperties": false,
+                            "metadata": {
+                                "minVersion": 7.0
+                            },
                             "patternProperties": {
                                 "^__[a-z]+__$": {}
                             },
@@ -2297,8 +2300,40 @@
                                         "composite"
                                     ]
                                 },
-                                "compop": {
+                                "compfilter": {
                                     "type": "string"
+                                },
+                                "compop": {
+                                    "enum": [
+                                        "clear",
+                                        "color-burn",
+                                        "color-dodge",
+                                        "contrast",
+                                        "darken",
+                                        "difference",
+                                        "dst",
+                                        "dst-atop",
+                                        "dst-in",
+                                        "dst-out",
+                                        "dst-over",
+                                        "exclusion",
+                                        "hard-light",
+                                        "invert",
+                                        "invert-rgb",
+                                        "lighten",
+                                        "minus",
+                                        "multiply",
+                                        "overlay",
+                                        "plus",
+                                        "screen",
+                                        "soft-light",
+                                        "src",
+                                        "src-atop",
+                                        "src-in",
+                                        "src-out",
+                                        "src-over",
+                                        "xor"
+                                    ]
                                 },
                                 "include": {
                                     "items": {

--- a/mappyfile/schemas/composite.json
+++ b/mappyfile/schemas/composite.json
@@ -4,9 +4,6 @@
   "patternProperties": {
     "^__[a-z]+__$": {}
   },
-  "metadata": {
-    "minVersion": 7.0
-  },
   "properties": {
     "__type__": {
       "enum": [ "composite" ]

--- a/mappyfile/schemas/composite.json
+++ b/mappyfile/schemas/composite.json
@@ -4,6 +4,9 @@
   "patternProperties": {
     "^__[a-z]+__$": {}
   },
+  "metadata": {
+    "minVersion": 7.0
+  },
   "properties": {
     "__type__": {
       "enum": [ "composite" ]
@@ -19,8 +22,40 @@
       "minimum": 0,
       "maximum": 100
     },
-    "compop": {
+    "compfilter": {
       "type": "string"
+    },
+    "compop": {
+      "enum": [
+        "clear",
+        "color-burn",
+        "color-dodge",
+        "contrast",
+        "darken",
+        "difference",
+        "dst",
+        "dst-atop",
+        "dst-in",
+        "dst-out",
+        "dst-over",
+        "exclusion",
+        "hard-light",
+        "invert",
+        "invert-rgb",
+        "lighten",
+        "minus",
+        "multiply",
+        "overlay",
+        "plus",
+        "screen",
+        "soft-light",
+        "src",
+        "src-atop",
+        "src-in",
+        "src-out",
+        "src-over",
+        "xor"
+      ]
     }
   }
 }

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -104,7 +104,7 @@ class Validator(object):
         version. Optionally provide a schema_name to return an expanded
         subsection of the full schema.
         """
-        jsn_schema = self.get_expanded_schema(schema_name)
+        jsn_schema = self.get_expanded_schema(schema_name, version)
 
         if version:
             # remove any properties based on minVersion and maxVersion
@@ -271,11 +271,18 @@ class Validator(object):
 
         return error_messages
 
-    def get_expanded_schema(self, schema_name):
+    def get_expanded_schema(self, schema_name, version=None):
         """
         Return a schema file with all $ref properties expanded
         """
-        if schema_name not in self.expanded_schemas:
+
+        # ensure we cache per version to handle validator reuse
+        if version is not None:
+            cache_schema_name = schema_name + str(version)
+        else:
+            cache_schema_name = schema_name
+
+        if cache_schema_name not in self.expanded_schemas:
             fn = self.get_schema_file(schema_name)
             schemas_folder = self.get_schemas_folder()
             base_uri = self.get_schema_path(schemas_folder)
@@ -284,8 +291,8 @@ class Validator(object):
                 jsn_schema = jsonref.load(f, base_uri=base_uri)
 
                 # cache the schema for future use
-                self.expanded_schemas[schema_name] = jsn_schema
+                self.expanded_schemas[cache_schema_name] = jsn_schema
         else:
-            jsn_schema = self.expanded_schemas[schema_name]
+            jsn_schema = self.expanded_schemas[cache_schema_name]
 
         return jsn_schema

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -598,6 +598,37 @@ def test_property_versioning():
     assert len(properties["force"]["oneOf"]) == 1
 
 
+def test_object_versioning():
+    """
+    Exclude whole objects if they were added in a
+    later version of MapServer
+    """
+
+    s = """MAP
+    NAME "sample"
+    LAYER
+        TYPE POLYGON
+        COMPOSITE
+            COMPOP "lighten"
+            OPACITY 50
+            COMPFILTER "blur(10)"
+        END
+    END
+END"""
+
+    d = mappyfile.loads(s, include_position=False)
+    v = Validator()
+    errors = v.validate(d, add_comments=True, version=6.0)
+    print(errors)
+    assert len(errors) == 1
+
+    d = mappyfile.loads(s, include_position=False)
+    #v = Validator()
+    errors = v.validate(d, add_comments=True, version=7.0)
+    print(errors)
+    assert len(errors) == 0
+
+
 def test_get_versioned_schema():
 
     validator = Validator()
@@ -613,8 +644,5 @@ def run_tests():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
-    test_property_versioning()
-    test_version_warnings()
-    test_keyword_versioning()
-    test_get_versioned_schema()
+    test_object_versioning()
     print("Done!")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -619,13 +619,10 @@ END"""
     d = mappyfile.loads(s, include_position=False)
     v = Validator()
     errors = v.validate(d, add_comments=True, version=6.0)
-    print(errors)
     assert len(errors) == 1
 
     d = mappyfile.loads(s, include_position=False)
-    #v = Validator()
     errors = v.validate(d, add_comments=True, version=7.0)
-    print(errors)
     assert len(errors) == 0
 
 


### PR DESCRIPTION
Fixes #144 by adding in missing keyword `compfilter`. As these are functions which can have variable values e.g. `COMPFILTER "blur(10)"` an enum cannot be used. 

Update also adds an enumerated list for `compop`. 

Finally, fixes a caching bug where if the same `Validation` object is used for different schema versions the same cached schema was returned. Now caching is done on a per version basis. 