### PR TITLE
Updates for COMPOSITE blocks

### DIFF
--- a/docs/schemas/mapfile-latest.json
+++ b/docs/schemas/mapfile-latest.json
@@ -2804,7 +2804,10 @@
                                     ]
                                 },
                                 "compfilter": {
-                                    "type": "string"
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "compop": {
                                     "enum": [
@@ -2836,7 +2839,8 @@
                                         "src-out",
                                         "src-over",
                                         "xor"
-                                    ]
+                                    ],
+                                    "type": "string"
                                 },
                                 "include": {
                                     "items": {

--- a/docs/schemas/mapfile-schema-7-6.json
+++ b/docs/schemas/mapfile-schema-7-6.json
@@ -2733,7 +2733,10 @@
                                     ]
                                 },
                                 "compfilter": {
-                                    "type": "string"
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "compop": {
                                     "enum": [
@@ -2765,7 +2768,8 @@
                                         "src-out",
                                         "src-over",
                                         "xor"
-                                    ]
+                                    ],
+                                    "type": "string"
                                 },
                                 "include": {
                                     "items": {

--- a/docs/schemas/mapfile-schema-8-0.json
+++ b/docs/schemas/mapfile-schema-8-0.json
@@ -2297,7 +2297,10 @@
                                     ]
                                 },
                                 "compfilter": {
-                                    "type": "string"
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "compop": {
                                     "enum": [
@@ -2329,7 +2332,8 @@
                                         "src-out",
                                         "src-over",
                                         "xor"
-                                    ]
+                                    ],
+                                    "type": "string"
                                 },
                                 "include": {
                                     "items": {

--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -12,7 +12,7 @@
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
     <InterpreterId>MSBuild|mappyfile|$(MSBuildProjectFullPath)</InterpreterId>
-    <StartupFile>tests\test_ordereddict.py</StartupFile>
+    <StartupFile>tests\test_snippets.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>PATH=C:\MapServer\bin;%PATH%

--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -431,7 +431,10 @@ class PrettyPrinter(object):
                 raise ValueError("The property {} has an empty dictionary as a value".format(attr))
 
             if not isinstance(value, numbers.Number):
-                return value.upper()  # value is from a set list, no need for quote
+                if attr == "compop":
+                    return self.quoter.add_quotes(value)
+                else:
+                    return value.upper()  # value is from a set list, no need for quote
             else:
                 return value
 

--- a/mappyfile/schemas/composite.json
+++ b/mappyfile/schemas/composite.json
@@ -20,9 +20,13 @@
       "maximum": 100
     },
     "compfilter": {
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "compop": {
+      "type": "string",
       "enum": [
         "clear",
         "color-burn",

--- a/mappyfile/tokens.py
+++ b/mappyfile/tokens.py
@@ -394,10 +394,10 @@ ms_errorfile
 """.split()) | COMPOSITE_NAMES
 
 # some keywords can be added multiple times to a composite type
-REPEATED_KEYS = ('processing', 'formatoption', 'include', 'data')
+REPEATED_KEYS = ('processing', 'formatoption', 'include', 'data', 'compfilter')
 
 # these are keywords used in the schema to store collections of composite objects
-# for example lists of lyaers
+# for example lists of layers
 OBJECT_LIST_KEYS = frozenset("""
 layers
 classes

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -998,6 +998,34 @@ def test_outputformat_unquoted_keyword():
     assert(output(s, schema_name="map") == exp)
 
 
+def test_multiple_composites():
+    """
+    See https://github.com/geographika/mappyfile/issues/150
+    """
+
+    s = u"""
+    LAYER
+        NAME "point-symbol-test"
+        TYPE POINT
+        COMPOSITE
+            COMPFILTER "blacken()"
+            COMPFILTER "translate(-6,-5)"
+            COMPFILTER "blur(7)"
+            COMPOP "soft-light"
+            OPACITY 50
+        END
+        COMPOSITE
+            OPACITY 100
+        END
+    END
+    """
+
+    print(output(s, schema_name="layer"))
+    exp = u"LAYER NAME 'point-symbol-test' TYPE POINT COMPOSITE COMPFILTER 'blacken()' " \
+    "COMPFILTER 'translate(-6,-5)' COMPFILTER 'blur(7)' COMPOP 'soft-light' OPACITY 50 END COMPOSITE OPACITY 100 END END"
+    assert(output(s, schema_name="layer") == exp)
+
+
 def run_tests():
     r"""
     Need to comment out the following line in C:\VirtualEnvs\mappyfile\Lib\site-packages\pep8.py
@@ -1010,6 +1038,6 @@ def run_tests():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    test_label_attribute_properties()
+    test_multiple_composites()
     # run_tests()
     print("Done!")

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -998,7 +998,7 @@ def test_outputformat_unquoted_keyword():
     assert(output(s, schema_name="map") == exp)
 
 
-def test_multiple_composites():
+def test_multiple_compfilters():
     """
     See https://github.com/geographika/mappyfile/issues/150
     """
@@ -1038,6 +1038,6 @@ def run_tests():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    test_multiple_composites()
+    test_multiple_compfilters()
     # run_tests()
     print("Done!")


### PR DESCRIPTION
Fixes for #150

- Multiple `COMPFILTER`s can be included in the block (there were no examples of these in docs or msautotest)
- `COMPOP` values were an enumerated list, but they should still be quoted in the output

Added a test for the above based on https://gist.github.com/LarsSchy/4aa75fd2a6bc7eb01a7cff9beb64b59a
