### PR TITLE
Support querying items without the given key in utils.findunique()

### DIFF
--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -496,7 +496,7 @@ def findunique(lst, key):
         groups = mappyfile.findunique(d["classes"], "group")
         assert groups == ["group1", "group2"]
     """
-    return sorted(set([item.get(key.lower(), None) for item in lst]) - {None,})
+    return sorted(set([item.get(key.lower(), None) for item in lst]) - {None, })
 
 
 def findkey(d, *keys):

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -496,7 +496,7 @@ def findunique(lst, key):
         groups = mappyfile.findunique(d["classes"], "group")
         assert groups == ["group1", "group2"]
     """
-    return sorted(set([item[key.lower()] for item in lst]))
+    return sorted(set([item.get(key.lower(), None) for item in lst]) - {None,})
 
 
 def findkey(d, *keys):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -315,6 +315,7 @@ def test_findunique():
     groups = mappyfile.findunique(d["classes"], "non-existent")
     assert groups == []
 
+
 def test_create_map():
     d = mappyfile.utils.create("map")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -312,6 +312,8 @@ def test_findunique():
     groups = mappyfile.findunique(d["classes"], "group")
     assert groups == ["group1", "group2"]
 
+    groups = mappyfile.findunique(d["classes"], "non-existent")
+    assert groups == []
 
 def test_create_map():
     d = mappyfile.utils.create("map")


### PR DESCRIPTION
Currently, `findunique()` throws a `TypeError` if any of the queried items do not have the key. My expectation was that these itemswould be ignored.