### PR TITLE
Adding lark-cython support

### DIFF
--- a/docs/scripts/benchmarks.py
+++ b/docs/scripts/benchmarks.py
@@ -1,0 +1,23 @@
+"""
+python -m timeit "import mappyfile; mappyfile.open(r'D:\GitHub\mappyfile\tests\mapfiles\large_map1.map')"
+
+With lark_cython:
+
+    1 loop, best of 5: 322 msec per loop
+
+With lark:
+
+    1 loop, best of 5: 373 msec per loop
+
+"""
+import timeit
+import mappyfile
+
+t = timeit.timeit(stmt="mappyfile.open(mf)",
+setup="import mappyfile; mf=r'D:/GitHub/mappyfile/tests/mapfiles/large_map1.map'", number=10)
+
+# 34.8 s with lark_cython
+# 38.5 without
+print(t)
+
+

--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
-    <InterpreterId>MSBuild|mappyfile|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|mappyfile3|$(MSBuildProjectFullPath)</InterpreterId>
     <StartupFile>tests\test_snippets.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
@@ -1040,6 +1040,9 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="docs\examples\geometry\geometry.py" />
+    <Compile Include="docs\scripts\benchmarks.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="docs\scripts\class_diagrams.py">
       <SubType>Code</SubType>
     </Compile>
@@ -1144,6 +1147,15 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Interpreter Include="C:\VirtualEnvs\mappyfile3\">
+      <Id>mappyfile3</Id>
+      <Version>3.10</Version>
+      <Description>mappyfile3 (Python 3.10 (64-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X64</Architecture>
+    </Interpreter>
     <Interpreter Include="C:\VirtualEnvs\mappyfile\">
       <Id>mappyfile</Id>
       <Version>2.7</Version>

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -32,7 +32,13 @@ import sys
 import logging
 from io import open
 from lark import Lark, ParseError, Tree, UnexpectedInput
-import lark_cython
+
+
+try:
+    import lark_cython
+    HAS_CYTHON = True
+except ImportError:
+    HAS_CYTHON = False
 
 
 PY2 = sys.version_info[0] < 3
@@ -65,7 +71,11 @@ class Parser(object):
             extra_args = dict(propagate_positions=True, lexer_callbacks=callbacks)
         else:
             extra_args = {}
-        return Lark(grammar_text, parser="lalr", lexer="contextual", _plugins=lark_cython.plugins, **extra_args)
+
+        if HAS_CYTHON is True:
+            extra_args["_plugins"] = lark_cython.plugins
+
+        return Lark(grammar_text, parser="lalr", lexer="contextual", **extra_args)
 
     def _get_include_filename(self, line):
 

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -32,6 +32,7 @@ import sys
 import logging
 from io import open
 from lark import Lark, ParseError, Tree, UnexpectedInput
+import lark_cython
 
 
 PY2 = sys.version_info[0] < 3
@@ -64,7 +65,7 @@ class Parser(object):
             extra_args = dict(propagate_positions=True, lexer_callbacks=callbacks)
         else:
             extra_args = {}
-        return Lark(grammar_text, parser="lalr", lexer="contextual", **extra_args)
+        return Lark(grammar_text, parser="lalr", lexer="contextual", _plugins=lark_cython.plugins, **extra_args)
 
     def _get_include_filename(self, line):
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='mappyfile',
       license='MIT',
       packages=['mappyfile'],
       install_requires=[
-            'lark-parser>=0.11.3',
+            'lark>=1.1.2',
             'lark_cython',
             # pyrsistent is a dependency of jsonschema but py2 is not
             # supported beyond 0.16.0

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name='mappyfile',
       packages=['mappyfile'],
       install_requires=[
             'lark-parser>=0.11.3',
+            'lark_cython',
             # pyrsistent is a dependency of jsonschema but py2 is not
             # supported beyond 0.16.0
             'pyrsistent<0.17.0; python_version=="2.7"',


### PR DESCRIPTION
Currently 12 failing tests relating to comment parsing. Possibly related to [1.0.0](https://github.com/lark-parser/lark/releases/tag/1.0.0) change:

> v_args(meta=True) now gives meta as the first argument. i.e. (meta, children).

However tests run fine without `lark-cython`.

Failing code:

```python
    def _assign_comments(self, _tree, prev_end_line):

        for node in _tree.children:
            if not isinstance(node, Tree):
                continue

            try:
>               line = node.meta.line
E               AttributeError: 'Meta' object has no attribute 'line'
```