### PR TITLE
Add option to avoid overwriting values in a dict with the update method

### DIFF
--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -12,7 +12,7 @@
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
     <InterpreterId>MSBuild|mappyfile3|$(MSBuildProjectFullPath)</InterpreterId>
-    <StartupFile>tests\test_validation.py</StartupFile>
+    <StartupFile>tests\test_utils.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>PATH=C:\MapServer\bin;%PATH%
@@ -114,7 +114,6 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Folder Include="tests\sample_maps\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include=".black" />
     <Content Include=".coveragerc" />
     <Content Include=".flake8" />
     <Content Include=".gitattributes" />
@@ -1067,7 +1066,6 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Compile Include="docs\examples\helper.py">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="docs\examples\grammar.py" />
     <Compile Include="docs\examples\image_from_mapfile.py">
       <SubType>Code</SubType>
     </Compile>

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -635,7 +635,7 @@ def findkey(d: dict, *keys: list[Any]) -> dict:
         return d
 
 
-def update(d1: dict, d2: dict) -> dict:
+def update(d1: dict, d2: dict, overwrite: bool = True) -> dict:
     """
     Update dict d1 with properties from d2
 
@@ -652,6 +652,8 @@ def update(d1: dict, d2: dict) -> dict:
         A Python dictionary
     d2: dict
         A Python dictionary that will be used to update any keys with the same name in d1
+    overwrite: boolean
+        If a key already exists in the dictionary should its value be overwritten
 
     Returns
     -------
@@ -671,7 +673,7 @@ def update(d1: dict, d2: dict) -> dict:
                 # allow a __delete__ property to be set to delete objects
                 del d1[k]
             else:
-                d1[k] = update(d1.get(k, {}), v)
+                d1[k] = update(d1.get(k, {}), v, overwrite)
         elif isinstance(v, (tuple, list)) and all(
             isinstance(li, (NoneType, dict)) for li in v  # type: ignore
         ):
@@ -690,7 +692,7 @@ def update(d1: dict, d2: dict) -> dict:
                 if new_item.get("__delete__", False):
                     d = None  # orig_list.remove(orig_item) # remove the item to delete
                 else:
-                    d = update(orig_item, new_item)
+                    d = update(orig_item, new_item, overwrite)
 
                 if d is not None:
                     new_list.append(d)
@@ -699,7 +701,8 @@ def update(d1: dict, d2: dict) -> dict:
             if k in d1 and v == "__delete__":
                 del d1[k]
             else:
-                d1[k] = v
+                if overwrite is True or k not in d1:
+                    d1[k] = v
     return d1
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -223,7 +223,99 @@ def test_update():
     d = mappyfile.update(d1, d2)
 
     output = mappyfile.dumps(d)
-    print(output)
+
+    expected = """MAP
+    LAYER
+        NAME "Layer1"
+        TYPE POLYGON
+    END
+    LAYER
+        NAME "LayerNew"
+        TYPE POINT
+        CLASS
+            NAME "Class1"
+            COLOR 0 0 255
+        END
+        CLASS
+            NAME "Class2"
+            COLOR 0 0 0
+        END
+    END
+END"""
+
+    assert output == expected
+
+
+def test_update_no_overrides():
+    s1 = """
+    MAP
+        LAYER
+            NAME "Layer1"
+            TYPE POLYGON
+        END
+        LAYER
+            NAME "Layer2"
+            TYPE POLYGON
+            CLASS
+                NAME "Class1"
+                COLOR 255 255 0
+            END
+        END
+    END
+    """
+
+    d1 = mappyfile.loads(s1)
+
+    s2 = """
+    MAP
+        LAYER
+            NAME "Layer1"
+            TYPE POLYGON
+        END
+        LAYER
+            NAME "LayerNew"
+            TYPE POINT
+            CLASS
+                NAME "ClassNew"
+                COLOR 0 0 255
+                GROUP "group1"
+            END
+            CLASS
+                NAME "Class2"
+                COLOR 0 0 0
+                GROUP "group2"
+            END
+        END
+    END
+    """
+
+    d2 = mappyfile.loads(s2)
+    d = mappyfile.update(d1, d2, overwrite=False)
+
+    output = mappyfile.dumps(d)
+
+    expected = """MAP
+    LAYER
+        NAME "Layer1"
+        TYPE POLYGON
+    END
+    LAYER
+        NAME "Layer2"
+        TYPE POLYGON
+        CLASS
+            NAME "Class1"
+            COLOR 255 255 0
+            GROUP "group1"
+        END
+        CLASS
+            NAME "Class2"
+            COLOR 0 0 0
+            GROUP "group2"
+        END
+    END
+END"""
+
+    assert output == expected
 
 
 def test_update_list():
@@ -407,5 +499,5 @@ def run_tests():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
-    test_create_label()
+    test_update_no_overrides()
     print("Done!")


### PR DESCRIPTION
This allows updating objects with defaults without overwriting existing values:

```
mappyfile.update(d1, d2, overwrite=False)
```

See test case for example. 

