### PR TITLE
Turn off proxies and lazy_load in jsonref

### DIFF
--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -12,7 +12,7 @@
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
     <InterpreterId>MSBuild|mappyfile3|$(MSBuildProjectFullPath)</InterpreterId>
-    <StartupFile>tests\test_utils.py</StartupFile>
+    <StartupFile>tests\test_validation.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>PATH=C:\MapServer\bin;%PATH%
@@ -1199,6 +1199,15 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Interpreter Include="C:\VirtualEnvs\mappyfile313\">
+      <Id>mappyfile313</Id>
+      <Version>0.0</Version>
+      <Description>mappyfile313 (Python 3.13 (64-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X64</Architecture>
+    </Interpreter>
     <Interpreter Include="C:\VirtualEnvs\mappyfile3\">
       <Id>mappyfile3</Id>
       <Version>3.10</Version>

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -318,7 +318,9 @@ class Validator:
             base_uri = self.get_schema_path(schemas_folder)
 
             with open(fn, encoding="utf-8") as f:
-                jsn_schema = jsonref.load(f, base_uri=base_uri)
+                jsn_schema = jsonref.load(
+                    f, base_uri=base_uri, lazy_load=False, proxies=False
+                )
 
                 # cache the schema for future use
                 self.expanded_schemas[cache_schema_name] = jsn_schema

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -333,6 +333,8 @@ def test_deref():
     print(json.dumps(deref_schema, indent=4))
     print(deref_schema["properties"]["filter"])
     assert list(deref_schema["properties"]["filter"].keys())[0] == "anyOf"
+    print(json.dumps(deref_schema["properties"]["filter"]))
+    assert json.dumps(deref_schema["properties"]["filter"]) is not None
 
 
 def test_cached_schema():
@@ -622,6 +624,7 @@ def run_tests():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    run_tests()
+    # run_tests()
     # test_double_error()
+    test_deref()
     print("Done!")


### PR DESCRIPTION
CI started failing when testing with Python 3.13, so ensure the full schema and all references are loaded to avoid proxies which cause `TypeError: Object of type dict is not JSON serializable` errors when using `json.dumps(deref_schema)`. 

See notes at https://github.com/gazpachoking/jsonref/issues/70. 
