### PR TITLE
Load expanded schemas

### DIFF
--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -88,9 +88,14 @@ class Validator:
     def get_json_from_file(self, schema_name: str):
         if schema_name not in self.schemas:
             schema_file = self.get_schema_file(schema_name)
+            schemas_folder = self.get_schemas_folder()
+            base_uri = self.get_schema_path(schemas_folder)
+
             with open(schema_file, encoding="utf-8") as f:
                 try:
-                    jsn_schema = json.load(f)
+                    jsn_schema = jsonref.load(
+                        f, base_uri=base_uri, lazy_load=False, proxies=False
+                    )
                 except ValueError as ex:
                     log.error("Could not load %s", schema_file)
                     raise ex
@@ -123,7 +128,7 @@ class Validator:
         return True
 
     def get_versioned_schema(
-        self, version: (float | None), schema_name: str = "map"
+        self, version: float | None, schema_name: str = "map"
     ) -> dict:
         """
         Get a fully expanded JSON schema for a specific MapServer
@@ -278,7 +283,7 @@ class Validator:
         value: Any,
         add_comments: bool = False,
         schema_name: str = "map",
-        version: (float | None) = None,
+        version: float | None = None,
     ):
         """
         verbose - also return the jsonschema error details
@@ -300,7 +305,7 @@ class Validator:
         return error_messages
 
     def get_expanded_schema(
-        self, schema_name: str, version: (float | None) = None
+        self, schema_name: str, version: float | None = None
     ) -> dict:
         """
         Return a schema file with all $ref properties expanded

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -618,6 +618,13 @@ def test_get_versioned_schema():
     assert "defresolution" in jsn["properties"].keys()
 
 
+def test_validating_mapfile():
+    fn = "./tests/sample_maps/256_overlay_res.map"
+    d = mappyfile.open(fn, expand_includes=True, include_position=True)
+    validation_messages = mappyfile.validate(d)
+    assert len(validation_messages) == 0
+
+
 def run_tests():
     pytest.main(["tests/test_validation.py"])
 
@@ -626,5 +633,5 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # run_tests()
     # test_double_error()
-    test_deref()
+    test_validating_mapfile()
     print("Done!")


### PR DESCRIPTION
To resolve following errors, due to full schema not loading all referenced schemas:

```
Run mappyfile schema mapfile-schema.json
tests/sample_maps/256_overlay_res.map (Line: 30 Column: 3) ERROR: Invalid value in TRANSPARENT - 'off' is not valid under any of the given schemas
1 file(s) validated (0 successfully)
```