### PR TITLE
Update JSON Schemas to Draft202012

### DIFF
--- a/mappyfile/pprint.py
+++ b/mappyfile/pprint.py
@@ -354,7 +354,9 @@ class PrettyPrinter:
 
     def check_options_list(self, options_list, value):
         for option in options_list:
-            if "enum" in option and value.lower() in option["enum"]:
+            if ("enum" in option and value.lower() in option["enum"]) or (
+                "const" in option and value.lower() in option["const"]
+            ):
                 if value.lower() == "end":
                     # in GEOTRANSFORM "end" is an attribute value
                     return self.quoter.add_quotes(value)

--- a/mappyfile/schemas/class.json
+++ b/mappyfile/schemas/class.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "class" ]
+      "const": "class"
     },
     "include": {
       "type": "array",
@@ -78,7 +78,7 @@
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "maxsize": {
@@ -91,8 +91,7 @@
       "$ref": "metadata.json"
     },
     "minfeaturesize": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "minscale": {
       "type": "number",
@@ -104,7 +103,7 @@
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "minsize": {
@@ -141,7 +140,7 @@
         "$ref": "style.json"
       },
       "metadata": {
-        "minVersion": 4.0
+        "minVersion": 4
       }
     },
     "symbol": {
@@ -173,5 +172,6 @@
     "validation": {
       "$ref": "validation.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/cluster.json
+++ b/mappyfile/schemas/cluster.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "cluster" ]
+      "const": "cluster"
     },
     "include": {
       "type": "array",
@@ -16,8 +16,7 @@
     },
     "maxdistance": {
       "type": "number",
-      "default": 10,
-      "exclusiveMinimum": 0
+      "default": 10
     },
     "region": {
       "oneOf": [
@@ -41,5 +40,6 @@
     "filter": {
       "$ref": "expression.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/color.json
+++ b/mappyfile/schemas/color.json
@@ -15,5 +15,6 @@
       "example": "#aa33cc",
       "type": "string"
     }
-  ]
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/composite.json
+++ b/mappyfile/schemas/composite.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "composite" ]
+      "const": "composite"
     },
     "include": {
       "type": "array",
@@ -58,5 +58,6 @@
         "xor"
       ]
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/connectionoptions.json
+++ b/mappyfile/schemas/connectionoptions.json
@@ -1,9 +1,9 @@
 {
   "type": "object",
-  "properties": {
-  },
+  "properties": {},
   "additionalProperties": true,
   "metadata": {
     "minVersion": 7.6
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/debug.json
+++ b/mappyfile/schemas/debug.json
@@ -1,3 +1,13 @@
 {
-  "enum": [ "on", "off", 0, 1, 2, 3, 4, 5 ]
+  "enum": [
+    "on",
+    "off",
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/expression.json
+++ b/mappyfile/schemas/expression.json
@@ -13,5 +13,6 @@
       "pattern": "^/(.*?)/$",
       "description": "regex"
     }
-  ]
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/extent.json
+++ b/mappyfile/schemas/extent.json
@@ -4,5 +4,6 @@
     "type": "number"
   },
   "minItems": 4,
-  "maxItems": 4
+  "maxItems": 4,
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/feature.json
+++ b/mappyfile/schemas/feature.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "feature" ]
+      "const": "feature"
     },
     "include": {
       "type": "array",
@@ -36,5 +36,6 @@
     "wkt": {
       "type": "string"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/grid.json
+++ b/mappyfile/schemas/grid.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "grid" ]
+      "const": "grid"
     },
     "include": {
       "type": "array",
@@ -20,35 +20,34 @@
           "type": "string"
         },
         {
-          "enum": [ "dd", "ddmm", "ddmmss" ]
+          "enum": [
+            "dd",
+            "ddmm",
+            "ddmmss"
+          ]
         }
       ]
     },
     "minarcs": {
       "type": "number",
-      "default": 16,
-      "exclusiveMinimum": 0
+      "default": 16
     },
     "maxarcs": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "mininterval": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "maxinterval": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "minsubdivide": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "maxsubdivide": {
       "type": "number",
-      "default": 256,
-      "exclusiveMinimum": 0
+      "default": 256
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/hex.json
+++ b/mappyfile/schemas/hex.json
@@ -1,5 +1,6 @@
 {
   "pattern": "^'#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})'$",
   "example": "'#aa33cc'",
-  "type": "string"
+  "type": "string",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/hex2.json
+++ b/mappyfile/schemas/hex2.json
@@ -1,5 +1,6 @@
 {
   "pattern": "^\"#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})\"$",
   "example": "'#aa33cc'",
-  "type": "string"
+  "type": "string",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/join.json
+++ b/mappyfile/schemas/join.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "join" ]
+      "const": "join"
     },
     "include": {
       "type": "array",
@@ -43,13 +43,21 @@
     },
     "type": {
       "type": "string",
-      "enum": [ "one-to-one", "one-to-many" ],
+      "enum": [
+        "one-to-one",
+        "one-to-many"
+      ],
       "additionalProperties": false
     },
     "connectiontype": {
       "type": "string",
-      "enum": [ "csv", "mysql", "postgresql" ],
+      "enum": [
+        "csv",
+        "mysql",
+        "postgresql"
+      ],
       "additionalProperties": false
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/label.json
+++ b/mappyfile/schemas/label.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "label" ]
+      "const": "label"
     },
     "include": {
       "type": "array",
@@ -18,7 +18,11 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": [ "left", "center", "right" ],
+          "enum": [
+            "left",
+            "center",
+            "right"
+          ],
           "additionalProperties": false
         },
         {
@@ -36,7 +40,11 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": [ "auto", "auto2", "follow" ],
+          "enum": [
+            "auto",
+            "auto2",
+            "follow"
+          ],
           "additionalProperties": false
         },
         {
@@ -49,7 +57,7 @@
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         }
       ]
@@ -65,7 +73,7 @@
         }
       ],
       "metadata": {
-        "maxVersion": 6.0
+        "maxVersion": 6
       }
     },
     "backgroundshadowcolor": {
@@ -75,7 +83,7 @@
         }
       ],
       "metadata": {
-        "maxVersion": 6.0
+        "maxVersion": 6
       }
     },
     "backgroundshadowsize": {
@@ -86,7 +94,7 @@
         }
       ],
       "metadata": {
-        "maxVersion": 6.0
+        "maxVersion": 6
       }
     },
     "buffer": {
@@ -95,13 +103,15 @@
     },
     "color": {
       "oneOf": [
-        { "$ref": "color.json" },
+        {
+          "$ref": "color.json"
+        },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         }
       ]
@@ -144,7 +154,7 @@
           "type": "boolean"
         },
         {
-          "enum": [ "group" ],
+          "const": "group",
           "metadata": {
             "minVersion": 6.2
           }
@@ -153,7 +163,6 @@
     },
     "maxlength": {
       "type": "integer",
-      "exclusiveMinimum": 0,
       "metadata": {
         "minVersion": 5.4
       }
@@ -164,7 +173,7 @@
       "minimum": 0,
       "maximum": 360,
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "maxscaledenom": {
@@ -176,19 +185,18 @@
     },
     "maxsize": {
       "type": "integer",
-      "default": 256,
-      "exclusiveMinimum": 0
+      "default": 256
     },
     "mindistance": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "minfeaturesize": {
       "oneOf": [
-        { "enum": [ "auto" ] },
         {
-          "type": "integer",
-          "exclusiveMinimum": 0
+          "const": "auto"
+        },
+        {
+          "type": "integer"
         }
       ]
     },
@@ -201,11 +209,13 @@
     },
     "minsize": {
       "type": "integer",
-      "exclusiveMinimum": 0,
       "default": 4
     },
     "offset": {
-      "default": [ 0, 0 ],
+      "default": [
+        0,
+        0
+      ],
       "oneOf": [
         {
           "type": "array",
@@ -232,20 +242,21 @@
     },
     "outlinecolor": {
       "oneOf": [
-        { "$ref": "color.json" },
+        {
+          "$ref": "color.json"
+        },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         }
       ]
     },
     "outlinewidth": {
       "type": "integer",
-      "exclusiveMinimum": 0,
       "default": 1
     },
     "partials": {
@@ -255,7 +266,9 @@
     "position": {
       "default": "cc",
       "oneOf": [
-        { "enum": [ "auto" ] },
+        {
+          "const": "auto"
+        },
         {
           "$ref": "position.json"
         },
@@ -291,13 +304,12 @@
         }
       ],
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "repeatdistance": {
       "type": "integer",
       "default": 0,
-      "exclusiveMinimum": 0,
       "metadata": {
         "minVersion": 5.6
       }
@@ -306,7 +318,10 @@
       "$ref": "color.json"
     },
     "shadowsize": {
-      "default": [ 1, 1 ],
+      "default": [
+        1,
+        1
+      ],
       "oneOf": [
         {
           "type": "array",
@@ -318,7 +333,7 @@
         },
         {
           "type": "array",
-          "items": [
+          "prefixItems": [
             {
               "type": "integer"
             },
@@ -331,21 +346,26 @@
           "minItems": 2,
           "maxItems": 2,
           "metadata": {
-            "minVersion": 6.0
+            "minVersion": 6
           }
         }
       ]
     },
     "size": {
       "default": 10,
-      "exclusiveMinimum": 1,
       "anyOf": [
         {
           "type": "integer"
         },
         {
           "type": "string",
-          "enum": [ "tiny", "small", "medium", "large", "giant" ],
+          "enum": [
+            "tiny",
+            "small",
+            "medium",
+            "large",
+            "giant"
+          ],
           "additionalProperties": false
         },
         {
@@ -353,7 +373,7 @@
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         },
         {
@@ -386,7 +406,10 @@
     },
     "type": {
       "type": "string",
-      "enum": [ "bitmap", "truetype" ],
+      "enum": [
+        "bitmap",
+        "truetype"
+      ],
       "additionalProperties": false
     },
     "wrap": {
@@ -394,5 +417,6 @@
       "minLength": 1,
       "maxLength": 1
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/layer.json
+++ b/mappyfile/schemas/layer.json
@@ -2,12 +2,14 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
-  "required": [ "type" ],
+  "required": [
+    "type"
+  ],
   "properties": {
     "__type__": {
-      "enum": [ "layer" ]
+      "const": "layer"
     },
     "__comments__": {
       "type": "object"
@@ -40,7 +42,7 @@
         }
       ],
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "composites": {
@@ -49,7 +51,7 @@
         "$ref": "composite.json"
       },
       "metadata": {
-        "minVersion": 7.0
+        "minVersion": 7
       }
     },
     "connection": {
@@ -66,7 +68,23 @@
       }
     },
     "connectiontype": {
-      "enum": [ "contour", "kerneldensity", "idw", "local", "ogr", "oraclespatial", "plugin", "postgis", "sde", "union", "uvraster", "wfs", "wms", "mygis", "flatgeobuf" ]
+      "enum": [
+        "contour",
+        "kerneldensity",
+        "idw",
+        "local",
+        "ogr",
+        "oraclespatial",
+        "plugin",
+        "postgis",
+        "sde",
+        "union",
+        "uvraster",
+        "wfs",
+        "wms",
+        "mygis",
+        "flatgeobuf"
+      ]
     },
     "data": {
       "type": "string"
@@ -78,7 +96,7 @@
         }
       ],
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "dump": {
@@ -97,7 +115,7 @@
     "encoding": {
       "type": "string",
       "metadata": {
-        "minVersion": 7.0
+        "minVersion": 7
       }
     },
     "extent": {
@@ -162,27 +180,27 @@
     "labelmaxscale": {
       "type": "number",
       "metadata": {
-        "maxVersion": 5.0
+        "maxVersion": 5
       }
     },
     "labelminscale": {
       "type": "number",
       "metadata": {
-        "maxVersion": 5.0
+        "maxVersion": 5
       }
     },
     "labelmaxscaledenom": {
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "labelminscaledenom": {
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "labelrequires": {
@@ -191,7 +209,7 @@
     "labelsizeitem": {
       "type": "string",
       "metadata": {
-        "maxVersion": 5.0
+        "maxVersion": 5
       }
     },
     "mask": {
@@ -201,12 +219,10 @@
       }
     },
     "maxfeatures": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "maxgeowidth": {
       "type": "number",
-      "exclusiveMinimum": 0,
       "metadata": {
         "minVersion": 5.4
       }
@@ -215,25 +231,23 @@
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "maxscale": {
       "type": "number",
       "metadata": {
-        "maxVersion": 5.0
+        "maxVersion": 5
       }
     },
     "metadata": {
       "$ref": "metadata.json"
     },
     "minfeaturesize": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "mingeowidth": {
       "type": "number",
-      "exclusiveMinimum": 0,
       "metadata": {
         "minVersion": 5.4
       }
@@ -242,13 +256,13 @@
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "minscale": {
       "type": "number",
       "metadata": {
-        "maxVersion": 5.0
+        "maxVersion": 5
       }
     },
     "name": {
@@ -291,12 +305,24 @@
       }
     },
     "sizeunits": {
-      "enum": [ "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "pixels" ]
+      "enum": [
+        "feet",
+        "inches",
+        "kilometers",
+        "meters",
+        "miles",
+        "nauticalmiles",
+        "pixels"
+      ]
     },
     "status": {
       "default": "off",
       "type": "string",
-      "enum": [ "on", "off", "default" ]
+      "enum": [
+        "on",
+        "off",
+        "default"
+      ]
     },
     "styleitem": {
       "type": "string"
@@ -305,7 +331,7 @@
       "type": "number",
       "minimum": 1,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "template": {
@@ -322,11 +348,19 @@
       "type": "string"
     },
     "tolerance": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "type": "number"
     },
     "toleranceunits": {
-      "enum": [ "pixels", "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "dd" ]
+      "enum": [
+        "pixels",
+        "feet",
+        "inches",
+        "kilometers",
+        "meters",
+        "miles",
+        "nauticalmiles",
+        "dd"
+      ]
     },
     "transparency": {
       "oneOf": [
@@ -334,7 +368,7 @@
           "type": "integer"
         },
         {
-          "enum": [ "alpha" ]
+          "const": "alpha"
         }
       ],
       "metadata": {
@@ -352,26 +386,47 @@
       ]
     },
     "type": {
-      "enum": [ "chart", "circle", "line", "point", "polygon", "raster", "query", "annotation", "tileindex" ]
+      "enum": [
+        "chart",
+        "circle",
+        "line",
+        "point",
+        "polygon",
+        "raster",
+        "query",
+        "annotation",
+        "tileindex"
+      ]
     },
     "units": {
       "default": "meters",
-      "enum": [ "dd", "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "percentages", "pixels" ]
+      "enum": [
+        "dd",
+        "feet",
+        "inches",
+        "kilometers",
+        "meters",
+        "miles",
+        "nauticalmiles",
+        "percentages",
+        "pixels"
+      ]
     },
     "utfdata": {
       "type": "string",
       "metadata": {
-        "minVersion": 7.0
+        "minVersion": 7
       }
     },
     "utfitem": {
       "type": "string",
       "metadata": {
-        "minVersion": 7.0
+        "minVersion": 7
       }
     },
     "validation": {
       "$ref": "validation.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/leader.json
+++ b/mappyfile/schemas/leader.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "leader" ]
+      "const": "leader"
     },
     "include": {
       "type": "array",
@@ -15,8 +15,7 @@
       }
     },
     "gridstep": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "maxdistance": {
       "type": "integer"
@@ -28,5 +27,6 @@
         "$ref": "style.json"
       }
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/legend.json
+++ b/mappyfile/schemas/legend.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "legend" ]
+      "const": "legend"
     },
     "include": {
       "type": "array",
@@ -28,7 +28,10 @@
       }
     },
     "keysize": {
-      "default": [ 20, 10 ],
+      "default": [
+        20,
+        10
+      ],
       "type": "array",
       "items": {
         "type": "integer",
@@ -39,7 +42,10 @@
       "maxItems": 2
     },
     "keyspacing": {
-      "default": [ 5, 5 ],
+      "default": [
+        5,
+        5
+      ],
       "type": "array",
       "items": {
         "type": "integer",
@@ -69,7 +75,11 @@
     "status": {
       "default": "off",
       "type": "string",
-      "enum": [ "on", "off", "embed" ]
+      "enum": [
+        "on",
+        "off",
+        "embed"
+      ]
     },
     "template": {
       "type": "string",
@@ -85,5 +95,6 @@
         "maxVersion": 7.6
       }
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/map.json
+++ b/mappyfile/schemas/map.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "map" ]
+      "const": "map"
     },
     "include": {
       "type": "array",
@@ -24,18 +24,30 @@
     "config": {
       "type": "object",
       "properties": {
-        "CGI_CONTEXT_URL": { "type": "string" },
-        "MS_ENCRYPTION_KEY": { "type": "string" },
-        "MS_ERRORFILE": { "type": "string" },
+        "CGI_CONTEXT_URL": {
+          "type": "string"
+        },
+        "MS_ENCRYPTION_KEY": {
+          "type": "string"
+        },
+        "MS_ERRORFILE": {
+          "type": "string"
+        },
         "MS_NONSQUARE": {
           "$ref": "yesno.json"
         },
         "ON_MISSING_DATA": {
           "type": "string",
           "default": "FAIL",
-          "enum": [ "FAIL", "LOG", "IGNORE" ]
+          "enum": [
+            "FAIL",
+            "LOG",
+            "IGNORE"
+          ]
         },
-        "PROJ_LIB": { "type": "string" }
+        "PROJ_LIB": {
+          "type": "string"
+        }
       },
       "additionalProperties": true
     },
@@ -53,7 +65,7 @@
         }
       ],
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "defresolution": {
@@ -139,7 +151,7 @@
       "type": "number",
       "minimum": 1,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "scalebar": {
@@ -149,7 +161,10 @@
       "type": "string"
     },
     "size": {
-      "default": [ -1, -1 ],
+      "default": [
+        -1,
+        -1
+      ],
       "type": "array",
       "items": {
         "type": "integer"

--- a/mappyfile/schemas/metadata.json
+++ b/mappyfile/schemas/metadata.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "properties": {
-  },
-  "additionalProperties": true
+  "properties": {},
+  "additionalProperties": true,
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/onoff.json
+++ b/mappyfile/schemas/onoff.json
@@ -1,4 +1,8 @@
 {
   "type": "string",
-  "enum": ["on", "off" ]
+  "enum": [
+    "on",
+    "off"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/outputformat.json
+++ b/mappyfile/schemas/outputformat.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "outputformat" ]
+      "const": "outputformat"
     },
     "__comments__": {
       "type": "object"
@@ -34,7 +34,15 @@
     },
     "imagemode": {
       "type": "string",
-      "enum": [ "pc256", "rgb", "rgba", "byte", "int16", "float32", "feature" ],
+      "enum": [
+        "pc256",
+        "rgb",
+        "rgba",
+        "byte",
+        "int16",
+        "float32",
+        "feature"
+      ],
       "additionalProperties": false
     },
     "mimetype": {
@@ -53,5 +61,6 @@
         }
       ]
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/points.json
+++ b/mappyfile/schemas/points.json
@@ -1,11 +1,12 @@
 {
+  "type": "array",
+  "items": {
     "type": "array",
     "items": {
-        "type": "array",
-        "items": {
-            "type": "number",
-            "minItems": 2,
-            "maxItems": 2
-        }
+      "type": "number",
+      "minItems": 2,
+      "maxItems": 2
     }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/position.json
+++ b/mappyfile/schemas/position.json
@@ -1,3 +1,14 @@
 {
-  "enum": [ "ul", "uc", "ur", "cl", "cc", "cr", "ll", "lc", "lr" ]
+  "enum": [
+    "ul",
+    "uc",
+    "ur",
+    "cl",
+    "cc",
+    "cr",
+    "ll",
+    "lc",
+    "lr"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/projection.json
+++ b/mappyfile/schemas/projection.json
@@ -7,6 +7,9 @@
       },
       "minItems": 1
     },
-    { "enum": [ "auto" ] }
-  ]
+    {
+      "const": "auto"
+    }
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/querymap.json
+++ b/mappyfile/schemas/querymap.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "querymap" ]
+      "const": "querymap"
     },
     "include": {
       "type": "array",
@@ -18,11 +18,14 @@
       "$ref": "color.json"
     },
     "size": {
-      "default": [ -1, -1 ],
+      "default": [
+        -1,
+        -1
+      ],
       "type": "array",
       "items": {
         "type": "integer",
-        "minimum":  -1
+        "minimum": -1
       },
       "minItems": 2,
       "maxItems": 2
@@ -34,8 +37,13 @@
     "style": {
       "default": "hilite",
       "type": "string",
-      "enum": [ "normal", "hilite", "selected" ],
+      "enum": [
+        "normal",
+        "hilite",
+        "selected"
+      ],
       "additionalProperties": false
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/reference.json
+++ b/mappyfile/schemas/reference.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "reference" ]
+      "const": "reference"
     },
     "include": {
       "type": "array",
@@ -36,16 +36,13 @@
       ]
     },
     "markersize": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "minboxsize": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "maxboxsize": {
-      "type": "integer",
-      "exclusiveMinimum": 0
+      "type": "integer"
     },
     "outlinecolor": {
       "$ref": "color.json"
@@ -62,5 +59,6 @@
     "status": {
       "$ref": "onoff.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/rgb.json
+++ b/mappyfile/schemas/rgb.json
@@ -6,5 +6,6 @@
     "maximum": 255
   },
   "minItems": 3,
-  "maxItems": 3
+  "maxItems": 3,
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/scalebar.json
+++ b/mappyfile/schemas/scalebar.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "scalebar" ]
+      "const": "scalebar"
     },
     "include": {
       "type": "array",
@@ -16,7 +16,11 @@
     },
     "align": {
       "type": "string",
-      "enum": [ "left", "center", "right" ],
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
       "additionalProperties": false,
       "metadata": {
         "minVersion": 5.2
@@ -61,7 +65,10 @@
       "type": "boolean"
     },
     "size": {
-      "default": [ 200, 3 ],
+      "default": [
+        200,
+        3
+      ],
       "type": "array",
       "items": {
         "type": "integer",
@@ -74,7 +81,11 @@
     "status": {
       "default": "off",
       "type": "string",
-      "enum": [ "on", "off", "embed" ]
+      "enum": [
+        "on",
+        "off",
+        "embed"
+      ]
     },
     "style": {
       "type": "integer",
@@ -130,9 +141,7 @@
       "metadata": {
         "minVersion": 7.2
       }
-    },
-    "outlinecolor": {
-      "$ref": "color.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/scaletoken.json
+++ b/mappyfile/schemas/scaletoken.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "scaletoken" ]
+      "const": "scaletoken"
     },
     "include": {
       "type": "array",
@@ -19,9 +19,9 @@
     },
     "values": {
       "type": "object",
-      "properties": {
-      },
+      "properties": {},
       "additionalProperties": true
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/sizeunits.json
+++ b/mappyfile/schemas/sizeunits.json
@@ -1,3 +1,12 @@
 {
-  "enum": ["feet", "inches", "kilometers", "meters", "miles", "nauticalmiles", "pixels"]
+  "enum": [
+    "feet",
+    "inches",
+    "kilometers",
+    "meters",
+    "miles",
+    "nauticalmiles",
+    "pixels"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/style.json
+++ b/mappyfile/schemas/style.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "style" ]
+      "const": "style"
     },
     "include": {
       "type": "array",
@@ -24,7 +24,9 @@
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute"
         },
-        { "enum": [ "auto" ] }
+        {
+          "const": "auto"
+        }
       ]
     },
     "angleitem": {
@@ -52,13 +54,15 @@
     },
     "color": {
       "oneOf": [
-        { "$ref": "color.json" },
+        {
+          "$ref": "color.json"
+        },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         }
       ]
@@ -94,13 +98,22 @@
     "gap": {
       "type": "number",
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "geomtransform": {
       "oneOf": [
         {
-          "enum": [ "bbox", "centroid", "end", "labelpnt", "labelpoly", "labelcenter", "start", "vertices" ]
+          "enum": [
+            "bbox",
+            "centroid",
+            "end",
+            "labelpnt",
+            "labelpoly",
+            "labelcenter",
+            "start",
+            "vertices"
+          ]
         },
         {
           "type": "string",
@@ -120,41 +133,47 @@
       }
     },
     "linecap": {
-      "enum": [ "butt", "round", "square" ],
+      "enum": [
+        "butt",
+        "round",
+        "square"
+      ],
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "linejoin": {
-      "enum": [ "round", "miter", "bevel", "none" ],
+      "enum": [
+        "round",
+        "miter",
+        "bevel",
+        "none"
+      ],
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "linejoinmaxsize": {
       "type": "integer",
-      "exclusiveMinimum": 0,
       "default": 3,
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "maxscaledenom": {
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "maxsize": {
       "type": "number",
-      "default": 500,
-      "exclusiveMinimum": 0
+      "default": 500
     },
     "maxwidth": {
       "type": "number",
-      "default": 32,
-      "exclusiveMinimum": 0
+      "default": 32
     },
     "minscaledenom": {
       "type": "number",
@@ -189,7 +208,9 @@
     },
     "opacity": {
       "oneOf": [
-        { "type": "integer" },
+        {
+          "type": "integer"
+        },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
@@ -202,13 +223,15 @@
     },
     "outlinecolor": {
       "oneOf": [
-        { "$ref": "color.json" },
+        {
+          "$ref": "color.json"
+        },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         }
       ]
@@ -237,7 +260,7 @@
         }
       ],
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "polaroffset": {
@@ -264,18 +287,16 @@
       "type": "string"
     },
     "size": {
-      "exclusiveMinimum": 1,
       "anyOf": [
         {
-          "type": "number",
-          "exclusiveMinimum": 0
+          "type": "number"
         },
         {
           "type": "string",
           "pattern": "^\\[(.*?)\\]$",
           "description": "attribute",
           "metadata": {
-            "minVersion": 5.0
+            "minVersion": 5
           }
         },
         {
@@ -308,7 +329,7 @@
       "oneOf": [
         {
           "type": "number",
-          "default": 1.0,
+          "default": 1,
           "minimum": 0
         },
         {
@@ -321,5 +342,6 @@
         }
       ]
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/symbol.json
+++ b/mappyfile/schemas/symbol.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "symbol" ]
+      "const": "symbol"
     },
     "include": {
       "type": "array",
@@ -15,20 +15,18 @@
       }
     },
     "anchorpoint": {
-      "type": "array",
-      "default": [ 0.5, 0.5 ],
-      "items": [
-        {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
+        "type": "array",
+        "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "minItems": 2,
+        "maxItems": 2,
+        "default": [ 0.5, 0.5 ],
+        "metadata": {
+            "minVersion": 6.2
         }
-      ],
-      "minItems": 2,
-      "maxItems": 2,
-      "metadata": {
-        "minVersion": 6.2
-      }
     },
     "antialias": {
       "type": "boolean",
@@ -79,7 +77,15 @@
       }
     },
     "type": {
-      "enum": [ "ellipse", "hatch", "pixmap", "svg", "truetype", "vector" ]
+      "enum": [
+        "ellipse",
+        "hatch",
+        "pixmap",
+        "svg",
+        "truetype",
+        "vector"
+      ]
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/symbolset.json
+++ b/mappyfile/schemas/symbolset.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "symbols": {

--- a/mappyfile/schemas/units.json
+++ b/mappyfile/schemas/units.json
@@ -1,3 +1,12 @@
 {
-  "enum": [ "dd", "feet", "inches", "kilometers", "meters", "miles", "nauticalmiles"]
+  "enum": [
+    "dd",
+    "feet",
+    "inches",
+    "kilometers",
+    "meters",
+    "miles",
+    "nauticalmiles"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/validation.json
+++ b/mappyfile/schemas/validation.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "properties": {
-  },
-  "additionalProperties": true
+  "properties": {},
+  "additionalProperties": true,
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/web.json
+++ b/mappyfile/schemas/web.json
@@ -2,11 +2,11 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^__[a-z]+__$": {}
+    "^__[a-z]+__$": true
   },
   "properties": {
     "__type__": {
-      "enum": [ "web" ]
+      "const": "web"
     },
     "include": {
       "type": "array",
@@ -54,14 +54,14 @@
       "type": "string",
       "description": "filename",
       "metadata": {
-        "maxVersion": 8.0
+        "maxVersion": 8
       }
     },
     "maxscaledenom": {
       "type": "number",
-      "minimum":  0,
+      "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "maxscale": {
@@ -80,7 +80,7 @@
       "type": "number",
       "minimum": 0,
       "metadata": {
-        "minVersion": 5.0
+        "minVersion": 5
       }
     },
     "minscale": {
@@ -103,11 +103,12 @@
       "type": "string",
       "description": "path",
       "metadata": {
-        "minVersion": 6.0
+        "minVersion": 6
       }
     },
     "validation": {
       "$ref": "validation.json"
     }
-  }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/schemas/yesno.json
+++ b/mappyfile/schemas/yesno.json
@@ -1,4 +1,8 @@
 {
   "type": "string",
-  "enum": [ "YES", "NO" ]
+  "enum": [
+    "YES",
+    "NO"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/mappyfile/validator.py
+++ b/mappyfile/validator.py
@@ -36,7 +36,7 @@ import jsonschema
 import jsonref
 from mappyfile import dictutils
 from referencing import Registry, Resource
-from referencing.jsonschema import DRAFT4
+from referencing.jsonschema import DRAFT202012
 from typing import Any
 
 
@@ -105,7 +105,7 @@ class Validator:
 
     def retrieve_from_filesystem(self, schema_name: str):
         jsn_schema = self.get_json_from_file(schema_name)
-        return Resource.from_contents(jsn_schema, default_specification=DRAFT4)
+        return Resource.from_contents(jsn_schema, default_specification=DRAFT202012)
 
     def is_valid_for_version(self, d: dict, version: float) -> bool:
         """
@@ -167,18 +167,16 @@ class Validator:
 
         return properties
 
-    def get_schema_validator(self, schema_name: str) -> jsonschema.Draft4Validator:
+    def get_schema_validator(self, schema_name: str) -> jsonschema.Draft202012Validator:
         """
-        Had to remove the id property from map.json or it uses URLs for validation
-        See various issues at https://github.com/Julian/jsonschema/pull/306
-        This is fixed in versions after Draft4
+        Create a schema validator
         """
 
         jsn_schema = self.get_json_from_file(schema_name)
 
         registry: Registry = Registry(retrieve=self.retrieve_from_filesystem)  # type: ignore
 
-        validator = jsonschema.Draft4Validator(schema=jsn_schema, registry=registry)  # type: ignore
+        validator = jsonschema.Draft202012Validator(schema=jsn_schema, registry=registry)  # type: ignore
         # validator.check_schema(jsn_schema) # check schema is valid - commented out as for testing only
 
         return validator
@@ -264,7 +262,7 @@ class Validator:
         return error_messages
 
     def _get_errors(
-        self, d: dict, validator: jsonschema.Draft4Validator, add_comments: bool
+        self, d: dict, validator: jsonschema.Draft202012Validator, add_comments: bool
     ) -> list[dict]:
         lowercase_dict = self.convert_lowercase(d)
         jsn = json.loads(json.dumps(lowercase_dict), object_pairs_hook=OrderedDict)
@@ -286,7 +284,7 @@ class Validator:
         """
         if version:
             jsn_schema = self.get_versioned_schema(version, schema_name)
-            validator = jsonschema.Draft4Validator(schema=jsn_schema)
+            validator = jsonschema.Draft202012Validator(schema=jsn_schema)
         else:
             validator = self.get_schema_validator(schema_name)
 


### PR DESCRIPTION
Update all schemas and validation code to use the draft 2020-12 JSON schema. 
Resolves #80 (skipping version 07 and going to the latest version). 