### PR TITLE
Remove dependency on jsonref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install .[lark_cython]
-          # temporary workaround for https://github.com/gazpachoking/jsonref/issues/71
-          pip uninstall --yes jsonref
-          pip install git+https://github.com/gazpachoking/jsonref.git@master -U
           pip list
       - name: Lint with flake8
         run: |

--- a/docs/scripts/make_json_schema.py
+++ b/docs/scripts/make_json_schema.py
@@ -1,6 +1,4 @@
 r"""
-jsonref
-
 Docs
 
 C:\VirtualEnvs\mappyfile\Scripts\activate.bat
@@ -12,7 +10,7 @@ jsonschema2rst %input_folder% %output_folder%
 
 import os
 import json
-from jsonschema import Draft4Validator
+from jsonschema import Draft202012Validator
 import glob
 from mappyfile.validator import Validator
 
@@ -22,7 +20,7 @@ def check_schema(fn):
 
     with open(fn) as f:
         jsn = json.load(f)
-        Draft4Validator.check_schema(jsn)
+        Draft202012Validator.check_schema(jsn)
 
 
 def save_full_schema(output_file):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = [
-    'jsonref',
     'glob2',
     'lark_cython',
     'PIL',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     install_requires=[
         "lark>=1.1.5",
         "jsonschema>=4.18.0",
-        "jsonref==1.1.0",
         "click",
     ],
     extras_require={


### PR DESCRIPTION
Removes `jsonref` dependency which has sone issues (with fixes not yet deployed to a PyPI release). 
Instead, use a custom ref resolver function with caching. This also improves performance of the test suite, as previously cached `.json` schema files used for validation weren't used by `jsonref` and had to be opened again. 

Before:

`255 passed, 2 xfailed in 102.19s (0:01:42)`

After:

`255 passed, 2 xfailed in 97.85s (0:01:37)`