### PR TITLE
Only add default MapServer values explicitly when using `create` function

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -1,6 +1,29 @@
 Releases
 --------
 
+1.1.0 Coming Soon
++++++++++++++++++
+
++ **Breaking Change** - :ref:`create <api-create>` now creates an empty block by default.
+  Pass ``add_default=True`` to include the default MapServer parameters.
+
+1.0.1 31/05/2024
+++++++++++++++++
+
+Patch release and CI (Continuous Integration) updates.
+
+`Full changlog <https://github.com/geographika/mappyfile/compare/v1.0.1...v1.0.2>`__.
+
+1.0.1 25/04/2024
+++++++++++++++++
+
+Patch release.
+
++ `#206 <https://github.com/geographika/mappyfile/pull/206>`_ - Ensure findall works when properties are missing
+
+`Full changlog <https://github.com/geographika/mappyfile/compare/v1.0.0...v1.0.1>`__.
+
+
 1.0.0 28/09/2023
 ++++++++++++++++
 

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -43,11 +43,17 @@ If MapServer uses default values for an object, the `create` function can be use
 a new object using these defaults. For example to output a `MAP` object with default settings
 run the following code:
 
+.. note::
+
+    From mappyfile 1.1+ by default an empty ``MAP END`` object is created. 
+    The value ``add_defaults=True`` has to be passed to ``create`` to add in
+    the MapServer default settings.
+
 .. code-block:: python
 
     import mappyfile
 
-    m = mappyfile.create("map", version=8.0)
+    m = mappyfile.create("map", version=8.0, add_defaults=True)
     print(m)
     mappyfile.dumps(m)
 

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -478,9 +478,9 @@ def _pprint(
     return pp.pprint(d)
 
 
-def create(type: str, version=None) -> dict:
+def create(type: str, version=None, add_defaults=False) -> dict:
     """
-    Create a new mappyfile object, using MapServer defaults (if any).
+    Create a new mappyfile object, and add MapServer defaults (if any).
 
     Parameters
     ----------
@@ -506,10 +506,10 @@ def create(type: str, version=None) -> dict:
     d = DefaultOrderedDict()
     d["__type__"] = type
 
-    properties = sorted(schema["properties"].items())
-
-    for key, value in properties:
-        if "default" in value:
-            d[key] = value["default"]
+    if add_defaults is True:
+        properties = sorted(schema["properties"].items())
+        for key, value in properties:
+            if "default" in value:
+                d[key] = value["default"]
 
     return d

--- a/run_local.ps1
+++ b/run_local.ps1
@@ -16,3 +16,10 @@ mypy mappyfile tests docs/examples --check-untyped-defs
 
 pytest --doctest-modules
 # pytest ./tests
+
+
+# docs
+
+sphinx-build -b html "./docs" "./_build" -W
+python -m http.server --directory=./_build 57921
+# http://localhost:57921

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,27 +118,36 @@ def test_dump_with_end_comments():
     assert output == 'MAP 	NAME "TEST" END # MAP'
 
 
-def test_create_map():
-    d = mappyfile.utils.create("map")
+def test_create_map_with_defaults():
+    d = mappyfile.utils.create("map", add_defaults=True)
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
     assert (
         output
         == "MAP ANGLE 0 DEBUG 0 DEFRESOLUTION 72 IMAGETYPE 'png' MAXSIZE 4096 NAME 'MS' RESOLUTION 72 SIZE -1 -1 END"
     )
 
 
-def test_create_layer():
-    d = mappyfile.utils.create("layer")
+def test_create_map():
+    d = mappyfile.utils.create("map")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
+    assert output == "MAP END"
+
+
+def test_create_layer_with_defaults():
+    d = mappyfile.utils.create("layer", add_defaults=True)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     assert output == "LAYER STATUS OFF TILEITEM 'location' UNITS METERS END"
 
 
-def test_create_label():
-    d = mappyfile.utils.create("label")
+def test_create_layer():
+    d = mappyfile.utils.create("layer", add_defaults=False)
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
+    assert output == "LAYER END"
+
+
+def test_create_label_with_defaults():
+    d = mappyfile.utils.create("label", add_defaults=True)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     assert (
         output
         == "LABEL ANGLE 0 ANTIALIAS FALSE BACKGROUNDSHADOWSIZE FALSE BUFFER 0 FORCE FALSE MAXOVERLAPANGLE 22.5 MAXSIZE 256 MINSIZE 4 "
@@ -146,25 +155,46 @@ def test_create_label():
     )
 
 
-def test_create_symbol():
-    d = mappyfile.utils.create("symbol")
+def test_create_label():
+    d = mappyfile.utils.create("label")
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
+    assert output == "LABEL END"
+
+
+def test_create_symbol_with_defaults():
+    d = mappyfile.utils.create("symbol", add_defaults=True)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
     assert output == "SYMBOL ANCHORPOINT 0.5 0.5 ANTIALIAS FALSE FILLED FALSE END"
+
+
+def test_create_symbol():
+    d = mappyfile.utils.create("symbol", add_defaults=False)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    assert output == "SYMBOL END"
+
+
+def test_create_symbol_v6_with_defaults():
+    d = mappyfile.utils.create("symbol", version=6.0, add_defaults=True)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    assert output == "SYMBOL ANTIALIAS FALSE FILLED FALSE END"
 
 
 def test_create_symbol_v6():
     d = mappyfile.utils.create("symbol", version=6.0)
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
-    assert output == "SYMBOL ANTIALIAS FALSE FILLED FALSE END"
+    assert output == "SYMBOL END"
+
+
+def test_create_symbol_v8_with_defaults():
+    d = mappyfile.utils.create("symbol", version=8.0, add_defaults=True)
+    output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
+    assert output == "SYMBOL ANCHORPOINT 0.5 0.5 FILLED FALSE END"
 
 
 def test_create_symbol_v8():
-    d = mappyfile.utils.create("symbol", version=8.0)
+    d = mappyfile.utils.create("symbol", version=8.0, add_defaults=False)
     output = mappyfile.dumps(d, indent=0, newlinechar=" ", quote="'")
-    print(output)
-    assert output == "SYMBOL ANCHORPOINT 0.5 0.5 FILLED FALSE END"
+    assert output == "SYMBOL END"
 
 
 def test_create_missing():


### PR DESCRIPTION
**Breaking Change** - `mappyfile.create` now creates an empty block by default. Pass `add_default=True` to include the default MapServer parameters.