### PR TITLE
Support quoted keys in CONFIG files

### DIFF
--- a/mappyfile/mapfile.lark
+++ b/mappyfile/mapfile.lark
@@ -32,9 +32,9 @@ start: "SYMBOLSET"i composite_body _END   -> symbolset
      | composite+
 
 _config_body: config_item*
-config_item: "ENV"i attr* _END -> env
-            | "MAPS"i attr* _END -> maps
-            | "PLUGINS"i attr* _END -> plugins
+config_item: "ENV"i config_attr* _END -> env
+            | "MAPS"i config_attr* _END -> maps
+            | "PLUGINS"i config_attr* _END -> plugins
 
 composite: composite_type composite_body _END
        | metadata
@@ -54,6 +54,9 @@ _composite_item: (composite|attr|points|projection|pattern|values|config|classau
 !metadata: "METADATA"i string_pair* _END
 !validation: "VALIDATION"i string_pair* _END
 !connectionoptions: "CONNECTIONOPTIONS"i string_pair* _END
+
+# allow quoted or unquoted keys for CONFIG sections
+config_attr: (UNQUOTED_STRING | composite_type | string) (value | UNQUOTED_STRING | UNQUOTED_STRING_VALUE)
 
 attr: (UNQUOTED_STRING | composite_type) (value | UNQUOTED_STRING | UNQUOTED_STRING_VALUE)
 %declare UNQUOTED_STRING_VALUE  // generated using the interactive parser. See issues #48, #98

--- a/mappyfile/parser.py
+++ b/mappyfile/parser.py
@@ -159,7 +159,13 @@ class Parser:
             # when we encounter a new type that can have associated comments
             # assign all comments up to that point in the Mapfile to the node
             # for metadata we want to assign comments to the string_pair
-            if node.data in ("composite", "attr", "projection", "string_pair"):
+            if node.data in (
+                "composite",
+                "attr",
+                "projection",
+                "string_pair",
+                "config_attr",
+            ):
                 # for projection blocks capture any comments within the block
 
                 if node.data in ("projection"):

--- a/mappyfile/transformer.py
+++ b/mappyfile/transformer.py
@@ -733,6 +733,7 @@ class CommentsTransformer(Transformer_InPlace):
 
     # below we assign callbacks to process comments for each of the following types
     attr = _save_attr_comments
+    config_attr = _save_attr_comments  # handled the same as other attr comments
     projection = _save_projection_comments
     composite = _save_composite_comments
 
@@ -787,6 +788,13 @@ class ConfigfileTransformer(MapfileTransformer):
             composite_dict[key] = atts_dict
 
         return composite_dict
+
+    def config_attr(self, tokens) -> dict:
+        """
+        Process CONFIG file attributes which can be quoted
+        or unquoted, otherwise they are identical to other attributes
+        """
+        return self.attr(tokens)
 
 
 class MapfileToDict:


### PR DESCRIPTION
Allows for the (valid) syntax:

```
    ENV
            MS_MAP_PATTERN "."
            # key in quotes
            "PROJ_LIB" "C:/MapServer/bin/proj7/SHARE"
    END
```

When pretty-printing quotes will be preserved, but keys will be unquoted by default. 