### PR TITLE
Add cli validation for CONFIG files

### DIFF
--- a/mappyfile/cli.py
+++ b/mappyfile/cli.py
@@ -221,13 +221,19 @@ def validate(_, mapfiles, expand, version):
             click.echo(f"{fn} failed to parse successfully")
             continue
 
-        validation_messages = mappyfile.validate(d, version)
+        schema_name = d.get("__type__", "map")
+        validation_messages = mappyfile.validate(d, version, schema_name)
         if validation_messages:
             for v in validation_messages:
                 v["fn"] = fn
-                # pylint: disable=consider-using-f-string
-                msg = "{fn} (Line: {line} Column: {column}) {message} - {error}".format(
-                    **v
+                msg = (
+                    "{fn} (Line: {line} Column: {column}) {message} - {error}"
+                ).format(
+                    fn=v.get("fn", "<unknown>"),
+                    line=v.get("line", "?"),
+                    column=v.get("column", "?"),
+                    message=v.get("message", ""),
+                    error=v.get("error", ""),
                 )
                 click.echo(msg)
                 errors += 1

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -443,7 +443,7 @@ def dumps(
     )
 
 
-def validate(d: dict, version: float | None = None) -> list:
+def validate(d: dict, version: float | None = None, schema_name: str = "map") -> list:
     """
     Validate a mappyfile dictionary by using the Mapfile schema.
     An optional version number can be used to specify a specific
@@ -465,7 +465,7 @@ def validate(d: dict, version: float | None = None) -> list:
 
     """
     v = Validator()
-    return v.validate(d, version=version)
+    return v.validate(d, version=version, schema_name=schema_name)
 
 
 def _save(output_file: str, string: str) -> None:
@@ -499,7 +499,8 @@ def _pprint(
 
 def create(type: str, version=None, add_defaults=False) -> dict:
     """
-    Create a new mappyfile object, and add MapServer defaults (if any).
+    Create a new mappyfile object. To add MapServer defaults (if any)
+    set ``add_defaults`` to ``True``.
 
     Parameters
     ----------


### PR DESCRIPTION
Add support for:

```bash
$ mappyfile validate C:\MapServer\apps\mapserver.conf
C:\MapServer\apps\mapserver.conf validated successfully
1 file(s) validated (1 successfully)
```