### PR TITLE
Remove codecs (only required for py2)

### DIFF
--- a/mappyfile/cli.py
+++ b/mappyfile/cli.py
@@ -29,7 +29,6 @@
 
 import sys
 import os
-import codecs
 import json
 import glob
 import logging
@@ -147,11 +146,12 @@ def format(
         mappyfile format C:/Temp/valid.map C:/Temp/valid_formatted.map --no-expand --comments
     """
 
-    quote = codecs.decode(quote, "unicode_escape")  # ensure \t is handled as a tab
-    spacer = codecs.decode(spacer, "unicode_escape")  # ensure \t is handled as a tab
-    newlinechar = codecs.decode(
-        newlinechar, "unicode_escape"
-    )  # ensure \n is handled as a newline
+    # ensure \t is handled as a tab
+    quote = quote.encode("raw_unicode_escape").decode("unicode_escape")
+    spacer = spacer.encode("raw_unicode_escape").decode("unicode_escape")
+
+    # ensure \n is handled as a newline
+    newlinechar = newlinechar.encode("raw_unicode_escape").decode("unicode_escape")
 
     d = mappyfile.open(
         input_mapfile,
@@ -271,7 +271,7 @@ def schema(_, output_file, version=None):
     validator = Validator()
     jsn = validator.get_versioned_schema(version)
 
-    with codecs.open(output_file, "w", encoding="utf-8") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(json.dumps(jsn, sort_keys=True, indent=4))
 
     sys.exit(0)

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -28,7 +28,6 @@
 # =================================================================
 
 from __future__ import annotations
-import codecs
 import warnings
 import functools
 from mappyfile.ordereddict import DefaultOrderedDict
@@ -469,7 +468,7 @@ def validate(d: dict, version: float | None = None, schema_name: str = "map") ->
 
 
 def _save(output_file: str, string: str) -> None:
-    with codecs.open(output_file, "w", encoding="utf-8") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(string)
 
 

--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -28,6 +28,9 @@
 # =================================================================
 
 from __future__ import annotations
+
+# pylint: disable=redefined-builtin
+import builtins
 import warnings
 import functools
 from mappyfile.ordereddict import DefaultOrderedDict
@@ -468,7 +471,7 @@ def validate(d: dict, version: float | None = None, schema_name: str = "map") ->
 
 
 def _save(output_file: str, string: str) -> None:
-    with open(output_file, "w", encoding="utf-8") as f:
+    with builtins.open(output_file, "w", encoding="utf-8") as f:
         f.write(string)
 
 

--- a/misc/docs_parser.py
+++ b/misc/docs_parser.py
@@ -20,7 +20,7 @@ https://github.com/sphinx-doc/sphinx/issues/2922#issuecomment-243377010
 Unfortunately, Sphinx is a monolithic application. So there is no way to use only parsers.
 """
 
-import glob, os, codecs
+import glob, os
 
 import docutils.frontend
 import docutils.nodes
@@ -257,7 +257,7 @@ class TermVisitor(docutils.nodes.GenericNodeVisitor):
 
 
 def read_doc(fn, kwds):
-    with codecs.open(fn, encoding="utf-8") as fileobj:
+    with open(fn, encoding="utf-8") as fileobj:
         txt = fileobj.read()
 
     txt = unicode(txt)


### PR DESCRIPTION
Fixes the warning:

```
mappyfile/utils.py:472: DeprecationWarning: [codecs.open](http://codecs.open/)() is deprecated. Use open() instead.
    with [codecs.open](http://codecs.open/)(output_file, "w", encoding="utf-8") as f
```