### PR TITLE
Write newlines exactly as in the string

### DIFF
--- a/mappyfile/utils.py
+++ b/mappyfile/utils.py
@@ -471,7 +471,7 @@ def validate(d: dict, version: float | None = None, schema_name: str = "map") ->
 
 
 def _save(output_file: str, string: str) -> None:
-    with builtins.open(output_file, "w", encoding="utf-8") as f:
+    with builtins.open(output_file, "w", encoding="utf-8", newline="") as f:
         f.write(string)
 
 


### PR DESCRIPTION
See https://docs.python.org/3/library/functions.html#open

> When reading input from the stream, if newline...is '', universal newlines mode is enabled, but line endings are returned to the caller untranslated. If it has any of the other legal values, input lines are only terminated by the given string, and the line ending is returned to the caller untranslated.

This ensures the `newline` parameter passed by the caller us unchanged by the platform. 