### PR TITLE
Add YAML import and export support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pip install .[lark_cython]
+          pip install .[lark_cython,yaml]
           pip list
       - name: Lint with flake8
         run: |
@@ -43,6 +43,8 @@ jobs:
           mappyfile schema mapfile-schema-8-2.json --version=8.2
           mappyfile validate tests/sample_maps/256_overlay_res.map
           mappyfile format tests/sample_maps/256_overlay_res.map tests/sample_maps/256_overlay_res_formatted.map
+          mappyfile yaml-export tests/sample_maps/256_overlay_res.map tests/sample_maps/256_overlay_res.yaml
+          mappyfile yaml-import tests/sample_maps/256_overlay_res.yaml tests/sample_maps/256_overlay_res_roundtrip.map
       - name: Test API examples
         run: |
           pytest docs/examples/api/

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ for better performance on CPython you can run the following command:
 
     pip install mappyfile[lark_cython]
 
+pip install mappyfile[lark_cython,yaml]
+
 mappyfile is also available on `conda <https://anaconda.org/conda-forge/mappyfile>`_. Install as
 follows:
 
@@ -91,13 +93,31 @@ From within Python scripts:
 
     print(mappyfile.dumps(mapfile, indent=1, spacer="\t"))
 
-Three command line tools are available - ``format``, ``validate``, and ``schema``:
+YAML support is available as an optional extra (``pip install mappyfile[yaml]``):
+
+.. code-block:: python
+
+    import mappyfile
+    import mappyfile.yaml
+
+    mapfile = mappyfile.open("./docs/examples/raster.map")
+
+    # export to YAML
+    mappyfile.yaml.save(mapfile, "raster.yaml")
+
+    # load back from YAML
+    mapfile2 = mappyfile.yaml.open("raster.yaml")
+    print(mappyfile.dumps(mapfile2))
+
+Command line tools are also available - ``format``, ``validate``, ``schema``, ``yaml-export``, and ``yaml-import``:
 
 .. code-block:: bat
 
     mappyfile format raster.map formatted_raster.map
     mappyfile validate D:\ms-ogc-workshop\ms4w\apps\ms-ogc-workshop\**\*.map
     mappyfile schema mapfile-schema-8-0.json --version=8.0
+    mappyfile yaml-export raster.map raster.yaml
+    mappyfile yaml-import raster.yaml raster.map
 
 Authors
 -------

--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -90,3 +90,45 @@ Mapfile schema. See :ref:`validation-docs` for further details.
     :noindex:
 
     .. autofunction:: validate
+
+.. _yaml-api:
+
+YAML Functions
+--------------
+
+These are functions used to read and write Mapfile dictionaries to YAML format.
+Requires PyYAML to be installed: ``pip install mappyfile[yaml]``.
+
++ :func:`mappyfile.yaml.open`
++ :func:`mappyfile.yaml.load`
++ :func:`mappyfile.yaml.loads`
++ :func:`mappyfile.yaml.dump`
++ :func:`mappyfile.yaml.dumps`
++ :func:`mappyfile.yaml.save`
+
+.. automodule:: mappyfile.yaml
+    :noindex:
+
+.. _api-yaml-open:
+
+    .. autofunction:: open
+
+.. _api-yaml-load:
+
+    .. autofunction:: load
+
+.. _api-yaml-loads:
+
+    .. autofunction:: loads
+
+.. _api-yaml-dump:
+
+    .. autofunction:: dump
+
+.. _api-yaml-dumps:
+
+    .. autofunction:: dumps
+
+.. _api-yaml-save:
+
+    .. autofunction:: save

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -129,3 +129,76 @@ Save the Mapfile schema to a file. Set the version parameter to output a specifi
 
 .. literalinclude:: schema.txt
     :language: console
+
+.. _client-yaml-export:
+
+yaml-export
+-----------
+
+The ``yaml-export`` command converts a Mapfile to YAML format. Requires PyYAML to be installed
+(``pip install mappyfile[yaml]``).
+
+Example 1
++++++++++
+
+To export a Mapfile to YAML using the default settings:
+
+.. code-block:: bat
+
+    mappyfile yaml-export mymap.map mymap.yaml
+
+Example 2
++++++++++
+
+To export without expanding any ``INCLUDE`` directives:
+
+.. code-block:: bat
+
+    mappyfile yaml-export mymap.map mymap.yaml --no-expand
+
+Example 3
++++++++++
+
+To export including any comments in the Mapfile:
+
+.. code-block:: bat
+
+    mappyfile yaml-export mymap.map mymap.yaml --comments
+
+To display the command's help text run the following:
+
+.. code-block:: bat
+
+    mappyfile yaml-export --help
+
+.. _client-yaml-import:
+
+yaml-import
+-----------
+
+The ``yaml-import`` command converts a YAML file back to a Mapfile. Requires PyYAML to be installed
+(``pip install mappyfile[yaml]``).
+
+Example 1
++++++++++
+
+To import a YAML file and save as a Mapfile using the default formatting settings:
+
+.. code-block:: bat
+
+    mappyfile yaml-import mymap.yaml mymap.map
+
+Example 2
++++++++++
+
+To import a YAML file and save as a Mapfile with custom indentation and single quotes:
+
+.. code-block:: bat
+
+    mappyfile yaml-import mymap.yaml mymap.map --indent=2 --quote="'"
+
+To display the command's help text run the following:
+
+.. code-block:: bat
+
+    mappyfile yaml-import --help

--- a/docs/examples/itasca.yaml
+++ b/docs/examples/itasca.yaml
@@ -1,0 +1,556 @@
+__type__: map
+name: ITASCA
+status: 'ON'
+size:
+- 600
+- 600
+projection:
+- init=epsg:26915
+extent:
+- 388107.634400379
+- 5203120.88405952
+- 500896.339019834
+- 5310243.30613897
+units: METERS
+shapepath: data
+imagecolor:
+- 255
+- 255
+- 255
+imagetype: PNG
+symbols:
+- __type__: symbol
+  name: circle
+  type: ELLIPSE
+  points:
+  - - 1
+    - 1
+  filled: true
+- __type__: symbol
+  name: star
+  type: VECTOR
+  filled: true
+  points:
+  - - 0
+    - 0.375
+  - - 0.35
+    - 0.375
+  - - 0.5
+    - 0
+  - - 0.65
+    - 0.375
+  - - 1
+    - 0.375
+  - - 0.75
+    - 0.625
+  - - 0.875
+    - 1
+  - - 0.5
+    - 0.75
+  - - 0.125
+    - 1
+  - - 0.25
+    - 0.625
+outputformats:
+- __type__: outputformat
+  name: geojson
+  driver: OGR/GEOJSON
+  mimetype: application/json
+  formatoption:
+  - FORM=SIMPLE
+  - STORAGE=memory
+- __type__: outputformat
+  name: png
+  driver: AGG/PNG
+  mimetype: image/png
+  imagemode: RGB
+  extension: png
+  formatoption:
+  - GAMMA=0.75
+  transparent: 'ON'
+web:
+  __type__: web
+  header: templates/header.html
+  template: itasca_basic.html
+  footer: templates/footer.html
+  minscaledenom: 1000
+  maxscaledenom: 1550000
+  imagepath: /var/www/html/tmp/
+  imageurl: /tmp/
+  metadata:
+    ows_title: MapServer Itasca Demo
+    ows_abstract: This is a MapServer demo application for Itasca County located in
+      north central Minnesota.
+    wms_accessconstraints: none
+    ows_enable_request: '*'
+    oga_html_template_directory: /usr/share/mapserver/ogcapi/templates/html-plain/
+    oga_onlineresource: http://localhost/cgi-bin/mapserv/itasca/ogcapi
+    ows_onlineresource: http://localhost/cgi-bin/mapserv?map=/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map&
+    wfs_srs: EPSG:26915 EPSG:3857 EPSG:4326
+    wfs_getfeature_formatlist: gml,geojson
+    wms_srs: EPSG:26915 EPSG:3857
+    __type__: metadata
+reference:
+  __type__: reference
+  image: graphics/reference.png
+  extent:
+  - 393234.393701263
+  - 5205405.16440722
+  - 495769.579718949
+  - 5307959.02579127
+  size:
+  - 120
+  - 120
+  status: 'ON'
+  minboxsize: 5
+  maxboxsize: 100
+  color:
+  - 255
+  - 0
+  - 0
+  outlinecolor:
+  - 0
+  - 0
+  - 0
+  markersize: 8
+  marker: star
+legend:
+  __type__: legend
+  keysize:
+  - 18
+  - 12
+  labels:
+  - __type__: label
+    type: BITMAP
+    size: MEDIUM
+    color:
+    - 0
+    - 0
+    - 89
+  status: 'ON'
+scalebar:
+  __type__: scalebar
+  imagecolor:
+  - 0
+  - 0
+  - 0
+  labels:
+  - __type__: label
+    color:
+    - 255
+    - 255
+    - 255
+    size: TINY
+  style: 1
+  size:
+  - 100
+  - 2
+  color:
+  - 255
+  - 255
+  - 255
+  units: MILES
+  intervals: 1
+  transparent: 'ON'
+  status: 'ON'
+layers:
+- __type__: layer
+  name: drgs
+  type: RASTER
+  status: 'OFF'
+  offsite:
+  - 252
+  - 252
+  - 252
+  classes:
+  - __type__: class
+    name: Digital Raster Graphic
+    keyimage: graphics/drgs_keyimage.png
+  metadata:
+    ows_title: USGS 1:250,000 Digital Raster Graphic
+    ows_abstract: Hibbing and Bemidji quadrangles.
+    wms_srs: EPSG:26915
+    __type__: metadata
+  tileindex: drgidx
+- __type__: layer
+  name: ctybdpy2
+  type: POLYGON
+  status: 'OFF'
+  data: ctybdpy2
+  template: ttt
+  requires: '![drgs]'
+  classitem: cty_name
+  classes:
+  - __type__: class
+    expression: Itasca
+    styles:
+    - __type__: style
+      outlinecolor:
+      - 128
+      - 128
+      - 128
+      color:
+      - 225
+      - 225
+      - 185
+  - __type__: class
+    expression: /./
+    styles:
+    - __type__: style
+      outlinecolor:
+      - 128
+      - 128
+      - 128
+      color:
+      - 255
+      - 255
+      - 255
+  metadata:
+    ows_title: County Boundary
+    ows_abstract: Itasca County boundary shapefile.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: mcd90py2
+  group: cities
+  type: POLYGON
+  data: mcd90py2
+  status: 'OFF'
+  classitem: city_name
+  classes:
+  - __type__: class
+    name: Cities & Towns
+    expression: /./
+    styles:
+    - __type__: style
+      color:
+      - 255
+      - 225
+      - 90
+    template: templates/mcd90py2.html
+  header: templates/mcd90py2_header.html
+  footer: templates/mcd90py2_footer.html
+  metadata:
+    ows_title: Minor Civil Divisions
+    ows_abstract: Minor civil divisions for Itasca County (boundaries only).
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: twprgpy3
+  type: POLYGON
+  data: twprgpy3
+  template: ttt
+  status: 'OFF'
+  classes:
+  - __type__: class
+    name: Townships
+    styles:
+    - __type__: style
+      symbol: circle
+      size: 2
+      outlinecolor:
+      - 181
+      - 181
+      - 145
+  metadata:
+    ows_title: Township Boundaries
+    ows_abstract: Pulic Land Survey (PLS) township boundaries for Itasca County.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: lakespy2
+  type: POLYGON
+  status: 'OFF'
+  data: lakespy2
+  projection:
+  - init=epsg:26915
+  classes:
+  - __type__: class
+    name: Lakes & Rivers
+    template: templates/lakespy2.html
+    styles:
+    - __type__: style
+      color:
+      - 49
+      - 117
+      - 185
+  header: templates/lakespy2_header.html
+  footer: templates/lakespy2_footer.html
+  tolerance: 3
+  metadata:
+    ows_title: Lakes and Rivers
+    ows_abstract: DLG lake and river polygons for Itasca County.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: dlgstln2
+  type: LINE
+  status: 'OFF'
+  data: dlgstln2
+  classes:
+  - __type__: class
+    name: Streams
+    template: templates/dlgstln2.html
+    styles:
+    - __type__: style
+      color:
+      - 49
+      - 117
+      - 185
+  header: templates/dlgstln2_header.html
+  footer: templates/dlgstln2_footer.html
+  tolerance: 5
+  metadata:
+    ows_title: Streams
+    ows_abstract: DLG streams for Itasca County.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: ctyrdln3
+  group: roads
+  maxscaledenom: 300000
+  status: 'OFF'
+  data: ctyrdln3
+  template: ttt
+  type: LINE
+  classes:
+  - __type__: class
+    styles:
+    - __type__: style
+      color:
+      - 0
+      - 0
+      - 0
+  projection:
+  - init=epsg:26915
+  metadata:
+    ows_title: County Roads
+    ows_abstract: County roads (lines only) derived from MNDOT roads layer.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: ctyrdln3_anno
+  group: roads
+  maxscaledenom: 300000
+  status: 'OFF'
+  data: ctyrdln3
+  template: ttt
+  type: LINE
+  labelitem: road_name
+  classes:
+  - __type__: class
+    labels:
+    - __type__: label
+      minfeaturesize: 40
+      mindistance: 150
+      position: CC
+      size: TINY
+      color:
+      - 0
+      - 0
+      - 0
+      styles:
+      - __type__: style
+        color:
+        - 255
+        - 255
+        - 255
+        symbol: symbols/ctyhwy.png
+  metadata:
+    ows_title: County Roads
+    ows_abstract: County roads (shields only) derived from MNDOT roads layer.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: majrdln3
+  group: roads
+  maxscaledenom: 600000
+  status: 'OFF'
+  data: majrdln3
+  template: ttt
+  type: LINE
+  classes:
+  - __type__: class
+    name: Roads
+    styles:
+    - __type__: style
+      color:
+      - 0
+      - 0
+      - 0
+  metadata:
+    ows_title: Highways
+    ows_abstract: Highways- state, US and interstate (lines only) derived from MNDOT
+      roads layer.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: majrdln3_anno
+  group: roads
+  maxscaledenom: 600000
+  status: 'OFF'
+  data: majrdln3
+  template: ttt
+  type: LINE
+  labelitem: road_num
+  classitem: road_class
+  classes:
+  - __type__: class
+    expression: '3'
+    labels:
+    - __type__: label
+      minfeaturesize: 50
+      mindistance: 150
+      position: CC
+      size: TINY
+      color:
+      - 0
+      - 0
+      - 0
+      styles:
+      - __type__: style
+        color:
+        - 0
+        - 0
+        - 0
+        symbol: symbols/sthwy.png
+  - __type__: class
+    expression: '2'
+    labels:
+    - __type__: label
+      minfeaturesize: 50
+      mindistance: 150
+      position: CC
+      size: TINY
+      color:
+      - 0
+      - 0
+      - 0
+      styles:
+      - __type__: style
+        color:
+        - 0
+        - 0
+        - 0
+        symbol: symbols/ushwy.png
+  - __type__: class
+    expression: '1'
+    labels:
+    - __type__: label
+      minfeaturesize: 50
+      mindistance: 150
+      position: CC
+      size: TINY
+      color:
+      - 255
+      - 255
+      - 255
+      styles:
+      - __type__: style
+        color:
+        - 0
+        - 0
+        - 0
+        symbol: symbols/interstate.png
+  metadata:
+    ows_title: Highways
+    ows_abstract: Highways- state, US and interstate (shields only) derived from MNDOT
+      roads layer.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: airports
+  type: POINT
+  data: airports
+  projection:
+  - init=epsg:26915
+  status: 'OFF'
+  classes:
+  - __type__: class
+    name: Airports
+    styles:
+    - __type__: style
+      color:
+      - 128
+      - 255
+      - 164
+      symbol: circle
+      size: 7
+    template: templates/airports.html
+  header: templates/airports_header.html
+  footer: templates/airports_footer.html
+  tolerance: 5
+  metadata:
+    ows_title: Airports
+    ows_abstract: Airport runways for Itasca County.
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata
+- __type__: layer
+  name: mcd90py2_anno
+  group: cities
+  template: ttt
+  type: POINT
+  data: mcd90py2
+  status: 'OFF'
+  labelitem: city_name
+  classitem: city_name
+  labelmaxscaledenom: 500000
+  classes:
+  - __type__: class
+    expression: /./
+    labels:
+    - __type__: label
+      color:
+      - 0
+      - 0
+      - 0
+      shadowcolor:
+      - 218
+      - 218
+      - 218
+      shadowsize:
+      - 2
+      - 2
+      type: BITMAP
+      size: MEDIUM
+      position: CC
+      partials: false
+      buffer: 2
+  metadata:
+    ows_title: Minor Civil Divisions
+    ows_abstract: Minor civil divisions for Itasca County (annotation only).
+    wms_srs: EPSG:26915
+    gml_include_items: all
+    gml_featureid: FID
+    gml_types: auto
+    __type__: metadata

--- a/docs/examples/yaml_example.py
+++ b/docs/examples/yaml_example.py
@@ -1,0 +1,15 @@
+import mappyfile
+import mappyfile.yaml
+
+d = mappyfile.open("./docs/examples/before.map")
+output = mappyfile.dumps(d)
+
+# Save to YAML
+mappyfile.yaml.save(d, "output.yaml")
+
+# Load back
+d2 = mappyfile.yaml.open("output.yaml")
+output2 = mappyfile.dumps(d2)
+
+print(output == output2)
+print(output2)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ mappyfile was first introduced in a presentation at `FOSS4G Europe 2017 <https:/
     comments.rst
     validation.rst
     schemas.rst
+    yaml.rst
     grammar.rst
     config.rst
     python_integration.rst
@@ -72,6 +73,13 @@ use in mappyfile you can set the ``MAPPYFILE_USE_CYTHON`` to ``False`` (or any f
 
     # Windows Command Line
     set MAPPYFILE_USE_CYTHON=False
+
+To install the optional `PyYAML <https://pyyaml.org/>`_ library for reading and writing
+Mapfiles in YAML format:
+
+.. code-block:: console
+
+    pip install mappyfile[yaml]
 
 mappyfile is also available on `conda <https://anaconda.org/conda-forge/mappyfile>`_. Install as
 follows:
@@ -146,13 +154,15 @@ Adding a new class to a layer:
     :start-after: # START OF ADD CLASS EXAMPLE
     :end-before: # END OF ADD CLASS EXAMPLE
 
-Three command line tools are also available - ``format``, ``validate``, and ``schema``:
+Command line tools are also available - ``format``, ``validate``, ``schema``, ``yaml-export``, and ``yaml-import``:
 
 .. code-block:: bat
 
     mappyfile format raster.map formatted_raster.map
     mappyfile validate D:\ms-ogc-workshop\ms4w\apps\ms-ogc-workshop\**\*.map
     mappyfile schema mapfile-schema-8-0.json --version=8.0
+    mappyfile yaml-export raster.map raster.yaml
+    mappyfile yaml-import raster.yaml raster.map
 
 What is mappyfile?
 ------------------
@@ -237,7 +247,6 @@ Future development plans include:
 + Setup an easy way to plug in "linters" to check various Mapfile settings and rules (e.g. configured correctly for WFS)
 + Create a Jupyter Notebook demonstrating mappyfile usage
 + Add a plugins page to the docs
-+ Add an example of creating Mapfiles using YAML
 + Create a new ``prune`` function to remove redundant default settings from a Mapfile
 
 

--- a/docs/yaml.rst
+++ b/docs/yaml.rst
@@ -1,0 +1,41 @@
+.. _yaml:
+
+YAML Support
+============
+
+YAML support was added in **version 1.2.0** of Mappyfile. The YAML format is supported for both loading and dumping Mapfiles.
+YAML is a human-readable data serialization format that is commonly used for configuration files.
+It is often preferred over JSON for its readability and support for comments.
+
+Python API Support:
+
+- :ref:`yaml-api`
+
+CLI Support:
+
+- :ref:`client-yaml-export`
+- :ref:`client-yaml-import`
+
+Python Example
+++++++++++++++
+
+.. literalinclude:: examples/yaml_example.py
+   :language: python
+
+Example YAML
+------------
+
+The following example shows how to export a Mapfile to YAML format using the command-line interface.
+
+.. code-block:: bat
+
+    mappyfile yaml-export ./tests/mapfiles/itasca2.map ./docs/examples/itasca.yaml
+
+The Mapfile used in this example is the "classic" MapServer Itasca map (``itasca2.map`` from the tests folder),
+and the output YAML file is saved to ``docs/examples/itasca.yaml`` and displayed below.
+
+.. literalinclude:: examples/itasca.yaml
+   :language: yaml
+
+.. literalinclude:: ../tests/mapfiles/itasca2.map
+   :language: mapfile

--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -267,7 +267,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Content Include="mappyfile\schemas\rgb.json" />
     <Content Include="mappyfile\schemas\layer.json" />
     <Content Include="mappyfile\schemas\map.json" />
-    <Content Include="mappyfile\yaml.py" />
+    <Content Include="mappyfile\yamlutils.py" />
     <Content Include="notes.private.txt" />
     <Content Include="pyproject.toml" />
     <Content Include="README.rst" />
@@ -897,6 +897,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Content Include="tests\sample_maps\point_pixmap.map" />
     <Content Include="tests\sample_maps\point_pixmap_gif.map" />
     <Content Include="tests\sample_maps\point_svg.map" />
+    <Content Include="tests\sample_maps\point_symbol_identification.map" />
     <Content Include="tests\sample_maps\point_truetype.map" />
     <Content Include="tests\sample_maps\point_vector.map" />
     <Content Include="tests\sample_maps\poly-label-multiline-pos-auto.map" />
@@ -1119,6 +1120,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     </Compile>
     <Compile Include="docs\examples\check_extents.py" />
     <Compile Include="docs\examples\geometry\geometry.py" />
+    <Compile Include="docs\examples\read_symbolset.py" />
     <Compile Include="docs\examples\yaml_example.py" />
     <Compile Include="docs\scripts\benchmarks.py">
       <SubType>Code</SubType>
@@ -1220,7 +1222,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Compile Include="tests\test_validation.py">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="tests\test_yaml.py" />
+    <Compile Include="tests\test_yamlutils.py" />
     <Compile Include="tests\__init__.py">
       <SubType>Code</SubType>
     </Compile>

--- a/mappyfile.pyproj
+++ b/mappyfile.pyproj
@@ -12,7 +12,7 @@
     <Name>mappyfile</Name>
     <RootNamespace>mappyfile</RootNamespace>
     <InterpreterId>MSBuild|mappyfile313|$(MSBuildProjectFullPath)</InterpreterId>
-    <StartupFile>tests\test_config.py</StartupFile>
+    <StartupFile>tests\test_utils.py</StartupFile>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <Environment>PATH=C:\MapServer\bin;%PATH%
@@ -267,6 +267,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Content Include="mappyfile\schemas\rgb.json" />
     <Content Include="mappyfile\schemas\layer.json" />
     <Content Include="mappyfile\schemas\map.json" />
+    <Content Include="mappyfile\yaml.py" />
     <Content Include="notes.private.txt" />
     <Content Include="pyproject.toml" />
     <Content Include="README.rst" />
@@ -1116,7 +1117,9 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Compile Include="docs\examples\api\readme.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="docs\examples\check_extents.py" />
     <Compile Include="docs\examples\geometry\geometry.py" />
+    <Compile Include="docs\examples\yaml_example.py" />
     <Compile Include="docs\scripts\benchmarks.py">
       <SubType>Code</SubType>
     </Compile>
@@ -1217,6 +1220,7 @@ PROJ_LIB=C:\MapServer\bin\proj\SHARE
     <Compile Include="tests\test_validation.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="tests\test_yaml.py" />
     <Compile Include="tests\__init__.py">
       <SubType>Code</SubType>
     </Compile>

--- a/mappyfile/__init__.py
+++ b/mappyfile/__init__.py
@@ -54,6 +54,11 @@ from mappyfile.dictutils import (
     dict_move_to_end,
 )
 
+from mappyfile import yamlutils as _yamlutils
+
+sys.modules["mappyfile.yaml"] = _yamlutils
+yaml = _yamlutils
+
 __version__ = "1.1.1"
 
 __all__ = [

--- a/mappyfile/cli.py
+++ b/mappyfile/cli.py
@@ -275,3 +275,91 @@ def schema(_, output_file, version=None):
         f.write(json.dumps(jsn, sort_keys=True, indent=4))
 
     sys.exit(0)
+
+
+@main.command(short_help="Export a Mapfile to YAML")
+@click.argument("input-mapfile", nargs=1, type=click.Path(exists=True))
+@click.argument("output-yaml", nargs=1, type=click.Path())
+@click.option(
+    "--expand/--no-expand",
+    default=True,
+    show_default=True,
+    help="Expand any INCLUDE directives found in the Mapfile",
+)
+@click.option(
+    "--comments/--no-comments",
+    default=False,
+    show_default=True,
+    help="Keep Mapfile comments in the output (experimental)",
+)
+@click.pass_context
+def yaml_export(_, input_mapfile, output_yaml, expand, comments):
+    """
+    Export a Mapfile to YAML format.
+
+    Example:
+
+        mappyfile yaml-export C:/Temp/mymap.map C:/Temp/mymap.yaml
+    """
+    import mappyfile.yaml
+
+    d = mappyfile.open(
+        input_mapfile,
+        expand_includes=expand,
+        include_comments=comments,
+    )
+    mappyfile.yaml.save(d, output_yaml)
+    click.echo(f"{input_mapfile} exported to {output_yaml}")
+    sys.exit(0)
+
+
+@main.command(short_help="Import a YAML file to a Mapfile")
+@click.argument("input-yaml", nargs=1, type=click.Path(exists=True))
+@click.argument("output-mapfile", nargs=1, type=click.Path())
+@click.option(
+    "--indent",
+    default=4,
+    show_default=True,
+    help="The number of spacer characters to indent structures in the Mapfile",
+)
+@click.option(
+    "--spacer",
+    default=" ",
+    help="The character to use for indenting structures in the Mapfile",
+)
+@click.option(
+    "--quote",
+    default='"',
+    help='The quote character to use in the Mapfile (double or single quotes). Ensure these are escaped e.g. \\" or \\\' [default: \\"]',
+)
+@click.option(
+    "--newlinechar",
+    default="\n",
+    help="The character used to insert newlines in the Mapfile [default: \\n]",
+)
+@click.pass_context
+def yaml_import(_, input_yaml, output_mapfile, indent, spacer, quote, newlinechar):
+    """
+    Import a YAML file and save as a Mapfile.
+
+    Example:
+
+        mappyfile yaml-import C:/Temp/mymap.yaml C:/Temp/mymap.map
+    """
+    import mappyfile.yaml
+
+    quote = quote.encode("raw_unicode_escape").decode("unicode_escape")
+    spacer = spacer.encode("raw_unicode_escape").decode("unicode_escape")
+    newlinechar = newlinechar.encode("raw_unicode_escape").decode("unicode_escape")
+
+    d = mappyfile.yaml.open(input_yaml)
+    mappyfile.save(
+        d,
+        output_mapfile,
+        indent=indent,
+        spacer=spacer,
+        quote=quote,
+        newlinechar=newlinechar,
+    )
+    click.echo(f"{input_yaml} imported to {output_mapfile}")
+    sys.exit(0)

--- a/mappyfile/yamlutils.py
+++ b/mappyfile/yamlutils.py
@@ -44,10 +44,15 @@ def _represent_as_mapping(dumper, data):
     return dumper.represent_mapping("tag:yaml.org,2002:map", data.items())
 
 
+def _represent_tuple(dumper, data):
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", data)
+
+
 def _make_dumper():
     dumper = yaml.Dumper
     dumper.add_representer(CaseInsensitiveOrderedDict, _represent_as_mapping)
     dumper.add_representer(DefaultOrderedDict, _represent_as_mapping)
+    dumper.add_representer(tuple, _represent_tuple)
     return dumper
 
 
@@ -76,7 +81,7 @@ def open(fn: str) -> dict:
         d = mappyfile.yaml.open('mymap.yaml')
 
     """
-    with builtins.open(fn) as f:
+    with builtins.open(fn, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
@@ -102,7 +107,7 @@ def load(fp: IO[str]) -> dict:
     To load a YAML file using an open file object::
 
         import mappyfile.yaml
-        with open('mymap.yaml') as fp:
+        with open('mymap.yaml', encoding='utf-8') as fp:
             d = mappyfile.yaml.load(fp)
 
     """
@@ -215,7 +220,7 @@ def save(d: dict, fn: str, **kwargs) -> str:
     """
     kwargs.setdefault("default_flow_style", False)
     kwargs.setdefault("allow_unicode", True)
-    with builtins.open(fn, "w") as f:
+    with builtins.open(fn, "w", encoding="utf-8") as f:
         yaml.dump(d, f, Dumper=_make_dumper(), **kwargs)
     return fn
 

--- a/mappyfile/yamlutils.py
+++ b/mappyfile/yamlutils.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 import builtins
+import collections
 from typing import IO
 
 try:
@@ -53,6 +54,7 @@ def _make_dumper():
     dumper.add_representer(CaseInsensitiveOrderedDict, _represent_as_mapping)
     dumper.add_representer(DefaultOrderedDict, _represent_as_mapping)
     dumper.add_representer(tuple, _represent_tuple)
+    dumper.add_representer(collections.OrderedDict, _represent_as_mapping)
     return dumper
 
 

--- a/mappyfile/yamlutils.py
+++ b/mappyfile/yamlutils.py
@@ -1,0 +1,257 @@
+# =================================================================
+#
+# Authors: Seth Girvin
+#
+# Copyright (c) 2026 Seth Girvin
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import builtins
+from typing import IO
+
+try:
+    import yaml
+except ImportError:
+    raise ImportError(
+        "PyYAML is required for YAML support: pip install mappyfile[yaml]"
+    )
+
+from mappyfile.ordereddict import CaseInsensitiveOrderedDict, DefaultOrderedDict
+
+
+def _represent_as_mapping(dumper, data):
+    return dumper.represent_mapping("tag:yaml.org,2002:map", data.items())
+
+
+def _make_dumper():
+    dumper = yaml.Dumper
+    dumper.add_representer(CaseInsensitiveOrderedDict, _represent_as_mapping)
+    dumper.add_representer(DefaultOrderedDict, _represent_as_mapping)
+    return dumper
+
+
+def open(fn: str) -> dict:
+    """
+    Load a Mapfile dictionary from a YAML file.
+
+    Parameters
+    ----------
+
+    fn: string
+        The path to the YAML file
+
+    Returns
+    -------
+
+    dict
+        A Python dictionary representing the Mapfile in the mappyfile format
+
+    Example
+    -------
+
+    To open a YAML file and return it as a dictionary object::
+
+        import mappyfile.yaml
+        d = mappyfile.yaml.open('mymap.yaml')
+
+    """
+    with builtins.open(fn) as f:
+        return yaml.safe_load(f)
+
+
+def load(fp: IO[str]) -> dict:
+    """
+    Load a Mapfile dictionary from an open YAML file or file-like object.
+
+    Parameters
+    ----------
+
+    fp: file
+        A file-like object
+
+    Returns
+    -------
+
+    dict
+        A Python dictionary representing the Mapfile in the mappyfile format
+
+    Example
+    -------
+
+    To load a YAML file using an open file object::
+
+        import mappyfile.yaml
+        with open('mymap.yaml') as fp:
+            d = mappyfile.yaml.load(fp)
+
+    """
+    return yaml.safe_load(fp)
+
+
+def loads(s: str) -> dict:
+    """
+    Load a Mapfile dictionary from a YAML string.
+
+    Parameters
+    ----------
+
+    s: string
+        A YAML string representing a Mapfile
+
+    Returns
+    -------
+
+    dict
+        A Python dictionary representing the Mapfile in the mappyfile format
+
+    Example
+    -------
+
+    To load a Mapfile dictionary from a YAML string::
+
+        import mappyfile.yaml
+        yaml_string = '''
+        __type__: map
+        name: MyMap
+        '''
+        d = mappyfile.yaml.loads(yaml_string)
+        assert d["name"] == "MyMap"
+
+    """
+    return yaml.safe_load(s)
+
+
+def dump(d: dict, fp: IO[str], **kwargs) -> None:
+    """
+    Write a Mapfile dictionary as a YAML formatted stream to fp.
+
+    Parameters
+    ----------
+
+    d: dict
+        A Python dictionary based on the mappyfile schema
+    fp: file
+        A file-like object
+    kwargs:
+        Additional keyword arguments passed to ``yaml.dump``, for example
+        ``sort_keys=False`` to preserve key order
+
+    Returns
+    -------
+
+    None
+
+    Example
+    -------
+
+    To open a Mapfile and dump it as YAML to an open file::
+
+        import mappyfile
+        import mappyfile.yaml
+
+        d = mappyfile.open('mymap.map')
+        with open('mymap.yaml', 'w') as fp:
+            mappyfile.yaml.dump(d, fp)
+
+    """
+    kwargs.setdefault("default_flow_style", False)
+    kwargs.setdefault("allow_unicode", True)
+    yaml.dump(d, fp, Dumper=_make_dumper(), **kwargs)
+
+
+def save(d: dict, fn: str, **kwargs) -> str:
+    """
+    Write a Mapfile dictionary to a YAML file on disk.
+
+    Parameters
+    ----------
+
+    d: dict
+        A Python dictionary based on the mappyfile schema
+    fn: string
+        The output filename
+    kwargs:
+        Additional keyword arguments passed to ``yaml.dump``, for example
+        ``sort_keys=False`` to preserve key order
+
+    Returns
+    -------
+
+    string
+          The output_file passed into the function
+
+    Example
+    -------
+
+    To open a Mapfile and save it as a YAML file::
+
+        import mappyfile
+        import mappyfile.yaml
+
+        d = mappyfile.open('mymap.map')
+        mappyfile.yaml.save(d, 'mymap.yaml')
+
+    """
+    kwargs.setdefault("default_flow_style", False)
+    kwargs.setdefault("allow_unicode", True)
+    with builtins.open(fn, "w") as f:
+        yaml.dump(d, f, Dumper=_make_dumper(), **kwargs)
+    return fn
+
+
+def dumps(d: dict, **kwargs) -> str:
+    """
+    Output a Mapfile dictionary as a YAML string.
+
+    Parameters
+    ----------
+
+    d: dict
+        A Python dictionary based on the mappyfile schema
+    kwargs:
+        Additional keyword arguments passed to ``yaml.dump``, for example
+        ``sort_keys=False`` to preserve key order
+
+    Returns
+    -------
+
+    string
+        The Mapfile as a YAML string
+
+    Example
+    -------
+
+    To output a Mapfile dictionary as a YAML string::
+
+        import mappyfile
+        import mappyfile.yaml
+
+        d = mappyfile.open('mymap.map')
+        yaml_string = mappyfile.yaml.dumps(d)
+        print(yaml_string)
+
+    """
+    kwargs.setdefault("default_flow_style", False)
+    kwargs.setdefault("allow_unicode", True)
+    return yaml.dump(d, Dumper=_make_dumper(), **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ module = [
     'glob2',
     'lark_cython',
     'PIL',
-    'shapely.geometry'
+    'shapely.geometry',
+    # ignore the virtual module
+    'mappyfile.yaml'
 ]
 ignore_missing_imports = true
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ black
 mypy
 types-jsonschema
 pyyaml
+types-PyYAML
 
 # for demo scripts
 Pillow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ sphinx
 black
 mypy
 types-jsonschema
+pyyaml
 
 # for demo scripts
 Pillow

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
         "lark_cython": [
             "lark_cython>=0.0.14",
         ],
+        "yaml": [
+            "pyyaml",
+        ],
     },
     zip_safe=False,
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,86 @@
 import logging
 import tempfile
-from mappyfile import cli
 import pytest
+from click.testing import CliRunner
+from mappyfile import cli
+
+
+MAPFILE_STRING = """
+MAP
+    NAME "TEST"
+    STATUS ON
+    EXTENT -180 -90 180 90
+    LAYER
+        NAME "test_layer"
+        TYPE POLYGON
+        STATUS ON
+        DATA "test"
+    END
+END
+"""
 
 
 def test_get_mapfiles():
     tf = tempfile.NamedTemporaryFile(suffix=".map")
     print(tf.name)
-
     mapfiles = [tf.name]
     found_mapfiles = cli.get_mapfiles(mapfiles)
     print(found_mapfiles)
+
+
+def test_yaml_export(tmp_path):
+    runner = CliRunner()
+    map_file = tmp_path / "test.map"
+    yaml_file = tmp_path / "test.yaml"
+    map_file.write_text(MAPFILE_STRING, encoding="utf-8")
+
+    result = runner.invoke(cli.main, ["yaml-export", str(map_file), str(yaml_file)])
+
+    assert result.exit_code == 0, result.output
+    assert yaml_file.exists()
+    assert "__type__: map" in yaml_file.read_text(encoding="utf-8")
+    assert f"{map_file} exported to {yaml_file}" in result.output
+
+
+def test_yaml_import(tmp_path):
+    runner = CliRunner()
+    map_file = tmp_path / "test.map"
+    yaml_file = tmp_path / "test.yaml"
+    output_map_file = tmp_path / "output.map"
+    map_file.write_text(MAPFILE_STRING, encoding="utf-8")
+
+    # first export to YAML
+    runner.invoke(cli.main, ["yaml-export", str(map_file), str(yaml_file)])
+
+    # then import back
+    result = runner.invoke(
+        cli.main, ["yaml-import", str(yaml_file), str(output_map_file)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_map_file.exists()
+    assert f"{yaml_file} imported to {output_map_file}" in result.output
+
+
+def test_yaml_roundtrip_cli(tmp_path):
+    runner = CliRunner()
+    map_file = tmp_path / "test.map"
+    yaml_file = tmp_path / "test.yaml"
+    output_map_file = tmp_path / "output.map"
+    map_file.write_text(MAPFILE_STRING, encoding="utf-8")
+
+    runner.invoke(cli.main, ["yaml-export", str(map_file), str(yaml_file)])
+    runner.invoke(cli.main, ["yaml-import", str(yaml_file), str(output_map_file)])
+
+    original = map_file.read_text(encoding="utf-8")
+    roundtrip = output_map_file.read_text(encoding="utf-8")
+
+    # compare by parsing both to normalise formatting
+    import mappyfile
+
+    d1 = mappyfile.loads(original)
+    d2 = mappyfile.loads(roundtrip)
+    assert mappyfile.dumps(d1) == mappyfile.dumps(d2)
 
 
 def run_tests():
@@ -19,6 +89,5 @@ def run_tests():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    # run_tests()
     test_get_mapfiles()
     print("Done!")

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -41,7 +41,7 @@ def test_all_maps():
     failing_maps = []
 
     for fn in os.listdir(sample_dir):
-        if fn not in ignore_list:
+        if fn not in ignore_list and fn.lower().endswith(".map"):
             print(fn)
             try:
                 ast = p.parse_file(os.path.join(sample_dir, fn))
@@ -72,7 +72,7 @@ def test_yaml_roundtrip_all_maps(tmp_path):
     failing_maps = []
 
     for fn in os.listdir(sample_dir):
-        if fn not in ignore_list:
+        if fn not in ignore_list and fn.lower().endswith(".map"):
             map_path = os.path.join(sample_dir, fn)
             yaml_path = tmp_path / f"{fn}.yaml"
             try:

--- a/tests/test_sample_maps.py
+++ b/tests/test_sample_maps.py
@@ -8,28 +8,31 @@ from mappyfile.pprint import PrettyPrinter
 from lark import UnexpectedToken
 from mappyfile.validator import Validator
 
+SAMPLE_DIR = os.path.join(os.path.dirname(__file__), "sample_maps")
+
+# the following "map" files are includes used by other mapfiles in msautotest
+# TODO - rename all these to .include in MapServer source to allow them to be more
+# easily processed
+
+IGNORE_LIST = [
+    "bdry_counpy2_mssql.map",
+    "bdry_counpy2_ogr.map",
+    "bdry_counpy2_postgis.map",
+    "bdry_counpy2_shapefile.map",
+    "indx_q100kpy4_ogr.map",
+    "indx_q100kpy4_shapefile.map",
+    "mssql_connection.map",
+    "quoted_text.MAP",
+    "style-size.map",
+    "wfs_ogr_export_metadata.map",
+]
+
 
 def test_all_maps():
-    sample_dir = os.path.join(os.path.dirname(__file__), "sample_maps")
-
-    # the following "map" files are includes used by other mapfiles in msautotest
-    # TODO - rename all these to .include in MapServer source to allow them to be more
-    # easily processed
-    ignore_list = [
-        "bdry_counpy2_mssql.map",
-        "bdry_counpy2_ogr.map",
-        "bdry_counpy2_postgis.map",
-        "bdry_counpy2_shapefile.map",
-        "indx_q100kpy4_ogr.map",
-        "indx_q100kpy4_shapefile.map",
-        "mssql_connection.map",
-        "quoted_text.MAP",
-        "style-size.map",
-        "wfs_ogr_export_metadata.map",
-    ]
+    sample_dir = SAMPLE_DIR
 
     # list any maps that are known not to parse and are to be fixed
-    ignore_list += ["centerline.map"]
+    ignore_list = IGNORE_LIST + ["centerline.map"]
 
     p = Parser(expand_includes=False)
     m = MapfileToDict(include_position=True)
@@ -57,6 +60,55 @@ def test_all_maps():
 
     logging.warning("The list of maps below have failed to parse")
     logging.warning(failing_maps)
+
+
+def test_yaml_roundtrip_all_maps(tmp_path):
+    import mappyfile.yaml
+
+    sample_dir = SAMPLE_DIR
+    ignore_list = IGNORE_LIST
+
+    v = Validator()
+    failing_maps = []
+
+    for fn in os.listdir(sample_dir):
+        if fn not in ignore_list:
+            map_path = os.path.join(sample_dir, fn)
+            yaml_path = tmp_path / f"{fn}.yaml"
+            try:
+                # load original mapfile
+                d = mappyfile.open(map_path, expand_includes=False)
+
+                # export to YAML
+                mappyfile.yaml.save(d, str(yaml_path))
+                assert yaml_path.exists(), f"YAML file not created for {fn}"
+
+                # load back from YAML
+                d2 = mappyfile.yaml.open(str(yaml_path))
+
+                # validate the round-tripped dict - log only, don't fail
+                errors = v.validate(d2)
+                if errors:
+                    logging.warning(
+                        "Validation errors after YAML round-trip for %s", fn
+                    )
+                    logging.warning(errors)
+
+                # compare output - log only, don't fail
+                original = mappyfile.dumps(d)
+                roundtrip = mappyfile.dumps(d2)
+                if original != roundtrip:
+                    logging.warning("Output mismatch after YAML round-trip for %s", fn)
+
+            except Exception as ex:
+                logging.warning("Cannot process %s for YAML round-trip", fn)
+                logging.error(ex)
+                failing_maps.append(fn)
+
+    if failing_maps:
+        logging.warning("The following maps failed YAML round-trip: %s", failing_maps)
+
+    assert len(failing_maps) == 0, f"YAML round-trip failed for: {failing_maps}"
 
 
 def test_includes():
@@ -149,5 +201,12 @@ if __name__ == "__main__":
     logging.getLogger("mappyfile").setLevel(logging.INFO)
     # run_tests()
     # test_unicode_map()
-    test_all_maps()
+    # test_all_maps()
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        test_yaml_roundtrip_all_maps(Path(tmp_dir))
+
     print("Done!")

--- a/tests/test_yamlutils.py
+++ b/tests/test_yamlutils.py
@@ -23,6 +23,21 @@ END
 """
 
 
+def test_yaml_import_error(monkeypatch):
+    import sys
+
+    # remove all relevant modules to force re-import
+    monkeypatch.delitem(sys.modules, "mappyfile.yaml", raising=False)
+    monkeypatch.delitem(sys.modules, "mappyfile.yamlutils", raising=False)
+    monkeypatch.delitem(sys.modules, "yaml", raising=False)
+
+    # make yaml unimportable
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    with pytest.raises(ImportError, match="PyYAML is required for YAML support"):
+        import mappyfile.yamlutils  # noqa: F401
+
+
 def test_yaml_dumps():
     d = mappyfile.loads(MAPFILE_STRING)
     yaml_string = mappyfile.yaml.dumps(d)

--- a/tests/test_yamlutils.py
+++ b/tests/test_yamlutils.py
@@ -1,0 +1,112 @@
+import pytest
+import logging
+import mappyfile
+import mappyfile.yaml
+
+MAPFILE_STRING = """
+MAP
+    NAME "TEST"
+    STATUS ON
+    EXTENT -180 -90 180 90
+    WEB
+        METADATA
+            "wms_title" "Test"
+        END
+    END
+    LAYER
+        NAME "test_layer"
+        TYPE POLYGON
+        STATUS ON
+        DATA "test"
+    END
+END
+"""
+
+
+def test_yaml_dumps():
+    d = mappyfile.loads(MAPFILE_STRING)
+    yaml_string = mappyfile.yaml.dumps(d)
+    assert "__type__: map" in yaml_string
+    assert "name: TEST" in yaml_string
+
+
+def test_yaml_loads():
+    d = mappyfile.loads(MAPFILE_STRING)
+    yaml_string = mappyfile.yaml.dumps(d)
+    d2 = mappyfile.yaml.loads(yaml_string)
+    assert d2["name"] == "TEST"
+    assert d2["__type__"] == "map"
+
+
+def test_yaml_roundtrip_string():
+    d = mappyfile.loads(MAPFILE_STRING)
+    original = mappyfile.dumps(d)
+    yaml_string = mappyfile.yaml.dumps(d)
+    d2 = mappyfile.yaml.loads(yaml_string)
+    roundtrip = mappyfile.dumps(d2)
+    assert original == roundtrip
+
+
+def test_yaml_open(tmp_path):
+    d = mappyfile.loads(MAPFILE_STRING)
+    original = mappyfile.dumps(d)
+    yaml_file = tmp_path / "test.yaml"
+    mappyfile.yaml.save(d, str(yaml_file))
+    assert yaml_file.exists()
+    d2 = mappyfile.yaml.open(str(yaml_file))
+    roundtrip = mappyfile.dumps(d2)
+    assert original == roundtrip
+
+
+def test_yaml_load(tmp_path):
+    d = mappyfile.loads(MAPFILE_STRING)
+    original = mappyfile.dumps(d)
+    yaml_file = tmp_path / "test.yaml"
+    mappyfile.yaml.save(d, str(yaml_file))
+    assert yaml_file.exists()
+    with open(str(yaml_file)) as fp:
+        d2 = mappyfile.yaml.load(fp)
+    roundtrip = mappyfile.dumps(d2)
+    assert original == roundtrip
+
+
+def test_yaml_save(tmp_path):
+    d = mappyfile.loads(MAPFILE_STRING)
+    yaml_file = tmp_path / "test.yaml"
+    result = mappyfile.yaml.save(d, str(yaml_file))
+    assert result == str(yaml_file)
+    assert yaml_file.exists()
+
+
+def test_yaml_dump(tmp_path):
+    d = mappyfile.loads(MAPFILE_STRING)
+    original = mappyfile.dumps(d)
+    yaml_file = tmp_path / "test.yaml"
+    with open(str(yaml_file), "w") as fp:
+        mappyfile.yaml.dump(d, fp)
+    assert yaml_file.exists()
+    d2 = mappyfile.yaml.open(str(yaml_file))
+    roundtrip = mappyfile.dumps(d2)
+    assert original == roundtrip
+
+
+def test_yaml_nested_objects():
+    d = mappyfile.loads(MAPFILE_STRING)
+    yaml_string = mappyfile.yaml.dumps(d)
+    d2 = mappyfile.yaml.loads(yaml_string)
+    assert d2["web"]["__type__"] == "web"
+    assert d2["web"]["metadata"]["wms_title"] == "Test"
+    assert d2["layers"][0]["name"] == "test_layer"
+
+
+def run_tests():
+    pytest.main(["tests/test_yaml.py"])
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    test_yaml_dumps()
+    test_yaml_loads()
+    test_yaml_roundtrip_string()
+    test_yaml_nested_objects()
+    print("Done!")

--- a/tests/test_yamlutils.py
+++ b/tests/test_yamlutils.py
@@ -124,4 +124,5 @@ if __name__ == "__main__":
     test_yaml_loads()
     test_yaml_roundtrip_string()
     test_yaml_nested_objects()
+    pytest.main([__file__ + "::test_yaml_import_error", "-v"])
     print("Done!")


### PR DESCRIPTION
Adds exporting Mapfiles to YAML, and importing the same YAML back to a Mapfile. 

```
pip install mappyfile[yaml]
```

```python
import mappyfile
import mappyfile.yaml

d = mappyfile.open("./docs/examples/before.map")
output = mappyfile.dumps(d)

# Save to YAML
mappyfile.yaml.save(d, "output.yaml")

# Load back
d2 = mappyfile.yaml.open("output.yaml")
output2 = mappyfile.dumps(d2)
```

CLI support:

```
mappyfile yaml-export raster.map raster.yaml
mappyfile yaml-import raster.yaml raster.map
```